### PR TITLE
fix bookshelves with enchanting tables

### DIFF
--- a/src/main/java/voronoiaoc/byg/common/properties/blocks/BookshelfBlock.java
+++ b/src/main/java/voronoiaoc/byg/common/properties/blocks/BookshelfBlock.java
@@ -1,9 +1,12 @@
 package voronoiaoc.byg.common.properties.blocks;
 
+import net.fabricmc.fabric.api.tag.TagRegistry;
 import net.minecraft.block.Block;
+import net.minecraft.tag.Tag;
+import net.minecraft.util.Identifier;
 
 public class BookshelfBlock extends Block {
-
+    public static Tag<Block> BOOKSHELF_TAG = TagRegistry.block(new Identifier("c","bookshelves"));
     protected BookshelfBlock(Settings builder) {
         super(builder);
     }

--- a/src/main/java/voronoiaoc/byg/mixin/common/AbstractBlockStateBookshelfMixin.java
+++ b/src/main/java/voronoiaoc/byg/mixin/common/AbstractBlockStateBookshelfMixin.java
@@ -1,0 +1,25 @@
+package voronoiaoc.byg.mixin.common;
+
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.tag.Tag;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import static voronoiaoc.byg.common.properties.blocks.BookshelfBlock.BOOKSHELF_TAG;
+
+@Mixin(AbstractBlock.AbstractBlockState.class)
+public abstract class AbstractBlockStateBookshelfMixin {
+    @Shadow public abstract boolean isIn(Tag<Block> tag);
+
+    @Inject(at=@At("HEAD"),method="isOf", cancellable = true)
+    private void isBookshelf(Block block, CallbackInfoReturnable<Boolean> info) {
+        if (block.equals(Blocks.BOOKSHELF)) {
+             info.setReturnValue(this.isIn(BOOKSHELF_TAG));
+        }
+    }
+}

--- a/src/main/resources/byg.mixins.json
+++ b/src/main/resources/byg.mixins.json
@@ -4,6 +4,7 @@
   "package": "voronoiaoc.byg.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "common.AbstractBlockStateBookshelfMixin",
     "common.FeatureMixin",
     "common.MixinDimensionType",
     "common.PlantBlockMixin"

--- a/src/main/resources/data/byg/tags/blocks/bookshelves.json
+++ b/src/main/resources/data/byg/tags/blocks/bookshelves.json
@@ -1,0 +1,25 @@
+{
+  "values": [
+      "byg:aspen_bookshelf",
+      "byg:baobab_bookshelf",
+      "byg:blue_enchanted_bookshelf",
+      "byg:cherry_bookshelf",
+      "byg:cika_bookshelf",
+      "byg:cypress_bookshelf",
+      "byg:ebony_bookshelf",
+      "byg:fir_bookshelf",
+      "byg:green_enchanted_bookshelf",
+      "byg:holly_bookshelf",
+      "byg:jacaranda_bookshelf",
+      "byg:mahogany_bookshelf",
+      "byg:mangrove_bookshelf",
+      "byg:maple_bookshelf",
+      "byg:pine_bookshelf",
+      "byg:rainbow_eucalyptus_bookshelf",
+      "byg:redwood_bookshelf",
+      "byg:skyris_bookshelf",
+      "byg:willow_bookshelf",
+      "byg:witch_hazel_bookshelf",
+      "byg:zelkova_bookshelf"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/bookshelves.json
+++ b/src/main/resources/data/c/tags/blocks/bookshelves.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:bookshelf",
+    "#byg:bookshelves"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/nylium.json
+++ b/src/main/resources/data/minecraft/tags/blocks/nylium.json
@@ -5,6 +5,6 @@
     "byg:embur_nylium",
     "byg:overgrown_netherrack",
     "byg:nylium_soul_soil",
-    "nylium_soul_sand"
+    "byg:nylium_soul_sand"
   ]
 }


### PR DESCRIPTION
use c:bookshelves tag for bookshelves to allow others to add their own to c:bookshelves for compatibility

add byg:bookshelves to the c:bookshelves tag to allow byg bookshelves to be used in other instances where bookshelf mods use tags
