### PR TITLE
Changed `BYGLeaves` to use the updated FabricBlockSettings

### DIFF
--- a/src/main/java/voronoiaoc/byg/common/properties/BYGBlockProperties.java
+++ b/src/main/java/voronoiaoc/byg/common/properties/BYGBlockProperties.java
@@ -2,12 +2,13 @@ package voronoiaoc.byg.common.properties;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.fabricmc.fabric.api.block.FabricBlockSettings;
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.tool.attribute.v1.FabricToolTags;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -490,7 +491,9 @@ public class BYGBlockProperties {
                     .sounds(SoundType.GRASS)
                     .nonOpaque()
                     .breakByTool(FabricToolTags.HOES, 0)
-                    .build()
+                    .suffocates((state, world, pos) -> false)
+                    .allowsSpawning((state, world, pos, type) -> type == EntityType.OCELOT || type == EntityType.PARROT)
+                    .blockVision((state, world, pos) -> false)
             );
 
             this.registerDefaultState(this.stateDefinition.any().setValue(DISTANCE, Integer.valueOf(7)).setValue(PERSISTENT, Boolean.valueOf(false)));


### PR DESCRIPTION
Also brought its properties more in line with those of vanilla leaves. This issue was brought to my attention by [an issue on one of my mods](https://github.com/Hephaestus-Dev/TinyTweaks/issues/25). On a side note, I noticed `BYGBlockProperties` creates a bunch of classes that are basically just wrappers for block settings. Block settings exist specifically to avoid an over-definition of classes, so I'd recommend changing that up.