### PR TITLE
added green_enchanted slab loot_table

### DIFF
--- a/src/main/resources/data/byg/loot_tables/blocks/green_enchanted_slab.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/green_enchanted_slab.json
@@ -1,0 +1,32 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "conditions": [
+                {
+                  "condition": "minecraft:block_state_property",
+                  "block": "byg:green_enchanted_slab",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
+          "name": "byg:green_enchanted_slab"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Green enchanted wood slabs were not dropping items when destroyed. I've added the missing loot table