### PR TITLE
Added Baobab & Joshua Fruit to the forge:fruits tag

### DIFF
--- a/src/main/resources/data/forge/tags/items/fruits.json
+++ b/src/main/resources/data/forge/tags/items/fruits.json
@@ -3,6 +3,8 @@
   "values": [
     "byg:blueberries",
     "byg:green_apple",
-    "byg:crimson_berries"
+    "byg:crimson_berries",
+    "byg:baobab_fruit",
+    "byg:joshua_fruit"
   ]
 }


### PR DESCRIPTION
Added Baobab & Joshua Fruit to the `forge:fruits` tag. This will improve compatibility with food mods such as Simple Farming.