### PR TITLE
Additional button tag for Create Compatibility

### DIFF
--- a/src/main/resources/data/minecraft/tags/items/wooden_buttons.json
+++ b/src/main/resources/data/minecraft/tags/items/wooden_buttons.json
@@ -1,0 +1,33 @@
+{
+  "replace": false,
+  "values": [
+    "byg:aspen_button",
+    "byg:baobab_button",
+    "byg:blue_enchanted_button",
+    "byg:cherry_button",
+    "byg:cika_button",
+    "byg:cypress_button",
+    "byg:ebony_button",
+    "byg:fir_button",
+    "byg:green_enchanted_button",
+    "byg:holly_button",
+    "byg:jacaranda_button",
+    "byg:mahogany_button",
+    "byg:mangrove_button",
+    "byg:maple_button",
+    "byg:pine_button",
+    "byg:rainbow_eucalyptus_button",
+    "byg:redwood_button",
+    "byg:skyris_button",
+    "byg:willow_button",
+    "byg:witch_hazel_button",
+    "byg:zelkova_button",
+    "byg:sythian_button",
+    "byg:embur_button",
+    "byg:palm_button",
+    "byg:lament_button",
+    "byg:ether_button",
+    "byg:bulbis_button",
+    "byg:nightshade_button"
+  ]
+}


### PR DESCRIPTION
This additional tag on BYG's wooden buttons will allow usage in Create some recipes.

Fixes issue in Enigmaitca 6: https://github.com/NillerMedDild/Enigmatica6/issues/636