### PR TITLE
Let lignite and anthracite be used in vanilla recipes that use coal or charcoal; add en_gb translation

### DIFF
--- a/src/main/resources/assets/byg/lang/en_gb.json
+++ b/src/main/resources/assets/byg/lang/en_gb.json
@@ -1,0 +1,44 @@
+{
+  "block.byg.chiseled_therium": "Chiselled Therium",
+  "block.byg.chiseled_therium_stairs": "Chiselled Therium Stairs",
+  "block.byg.chiseled_therium_slab": "Chiselled Therium Slab",
+  "block.byg.chiseled_therium_wall": "Chiselled Therium Wall",
+  "block.byg.shiny_chiseled_therium": "Shiny Chiselled Therium",
+  "block.byg.shiny_chiseled_therium_stairs": "Shiny Chiselled Therium Stairs",
+  "block.byg.shiny_chiseled_therium_slab": "Shiny Chiselled Therium Slab",
+  "block.byg.shiny_chiseled_therium_wall": "Shiny Chiselled Therium Wall",
+  
+  "item.byg.chiseled_therium": "Chiselled Therium",
+  "item.byg.chiseled_therium_stairs": "Chiselled Therium Stairs",
+  "item.byg.chiseled_therium_slab": "Chiselled Therium Slab",
+  "item.byg.chiseled_therium_wall": "Chiselled Therium Wall",
+  "item.byg.shiny_chiseled_therium": "Shiny Chiselled Therium",
+  "item.byg.shiny_chiseled_therium_stairs": "Shiny Chiselled Therium Stairs",
+  "item.byg.shiny_chiseled_therium_slab": "Shiny Chiselled Therium Slab",
+  "item.byg.shiny_chiseled_therium_wall": "Shiny Chiselled Therium Wall",
+  
+  "block.byg.black_chiseled_sandstone": "Black Chiselled Sandstone",
+  "block.byg.white_chiseled_sandstone": "White Chiselled Sandstone",
+  "block.byg.blue_chiseled_sandstone": "Blue Chiselled Sandstone",
+  "block.byg.purple_chiseled_sandstone": "Purple Chiselled Sandstone",
+  "block.byg.pink_chiseled_sandstone": "Pink Chiselled Sandstone",
+  
+  "item.byg.black_chiseled_sandstone": "Black Chiselled Sandstone",
+  "item.byg.white_chiseled_sandstone": "White Chiselled Sandstone",
+  "item.byg.blue_chiseled_sandstone": "Blue Chiselled Sandstone",
+  "item.byg.purple_chiseled_sandstone": "Purple Chiselled Sandstone",
+  "item.byg.pink_chiseled_sandstone": "Pink Chiselled Sandstone",
+  
+  "block.byg.chiseled_red_rock_bricks": "Chiselled Red Rock Bricks",
+  "block.byg.chiseled_red_rock_brick_slab": "Chiselled Red Rock Brick Slab",
+  "block.byg.chiseled_red_rock_brick_stairs": "Chiselled Red Rock Brick Stairs",
+  "block.byg.chiseled_red_rock_brick_wall": "Chiselled Red Rock Brick Wall",
+  
+  "item.byg.chiseled_red_rock_bricks": "Chiselled Red Rock Bricks",
+  "item.byg.chiseled_red_rock_brick_stairs": "Chiselled Red Rock Brick Stairs",
+  "item.byg.chiseled_red_rock_brick_slab": "Chiselled Red Rock Brick Slab",
+  "item.byg.chiseled_red_rock_brick_wall": "Chiselled Red Rock Brick Wall",
+  
+  "item.byg.ametrine_horse_armor": "Ametrine Horse Armour",
+  "item.byg.pendorite_horse_armor": "Pendorite Horse Armour"
+}

--- a/src/main/resources/data/byg/recipes/fire_charge_from_byg_coals.json
+++ b/src/main/resources/data/byg/recipes/fire_charge_from_byg_coals.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:gunpowder"
+    },
+    {
+      "item": "minecraft:blaze_powder"
+    },
+    [
+      {
+        "item": "byg:lignite"
+      },
+      {
+        "item": "byg:anthracite"
+      }
+    ]
+  ],
+  "result": {
+    "item": "minecraft:fire_charge",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/soul_torch_from_byg_coals.json
+++ b/src/main/resources/data/byg/recipes/soul_torch_from_byg_coals.json
@@ -1,0 +1,27 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "X",
+    "#",
+    "S"
+  ],
+  "key": {
+    "X": {
+        "item": "byg:lignite"
+      },
+      {
+        "item": "byg:anthracite"
+      }
+    ],
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "S": {
+      "tag": "minecraft:soul_fire_base_blocks"
+    }
+  },
+  "result": {
+    "item": "minecraft:soul_torch",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/byg/recipes/torch_from_byg_coals.json
+++ b/src/main/resources/data/byg/recipes/torch_from_byg_coals.json
@@ -8,9 +8,14 @@
     "#": {
       "item": "minecraft:stick"
     },
-    "X": {
+    "X": [
+      {
         "item": "byg:lignite"
-    },
+      },
+      {
+        "item": "byg:anthracite"
+      }
+    ]
   },
   "result": {
     "item": "minecraft:torch",

--- a/src/main/resources/data/byg/recipes/torch_from_lignite.json
+++ b/src/main/resources/data/byg/recipes/torch_from_lignite.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "X",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "X": {
+        "item": "byg:lignite"
+    },
+  },
+  "result": {
+    "item": "minecraft:torch",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/minecraft/tags/items/coals.json
+++ b/src/main/resources/data/minecraft/tags/items/coals.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:lignite"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/coals.json
+++ b/src/main/resources/data/minecraft/tags/items/coals.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "byg:lignite"
+    "byg:lignite",
+    "byg:anthracite"
   ]
 }


### PR DESCRIPTION
Lignite and anthracite cannot be used to make vanilla recipes that ask for coal or charcoal, despite being coal variants. This pull request adds lignite and anthracite to the `#minecraft:coals` tag so the campfire recipe can recognise them, and adds new recipes for the torch, soul torch and fire charge that use them as well, as these vanilla recipes do not use the above tag for whatever reason.

I also created an en_gb translation file, with the British spellings of 'chiselled' and 'armour' for every block and item that uses these words.