### PR TITLE
Various fixes and adjustments to improve mod compatibility

### DIFF
--- a/src/main/resources/data/byg/recipes/acacia_sign_from_baobab_planks.json
+++ b/src/main/resources/data/byg/recipes/acacia_sign_from_baobab_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:baobab_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/acacia_sign_from_cika_planks.json
+++ b/src/main/resources/data/byg/recipes/acacia_sign_from_cika_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:cika_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/acacia_sign_from_maple_planks.json
+++ b/src/main/resources/data/byg/recipes/acacia_sign_from_maple_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:maple_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/acacia_sign_from_palm_planks.json
+++ b/src/main/resources/data/byg/recipes/acacia_sign_from_palm_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:palm_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/acacia_sign_from_redwood_planks.json
+++ b/src/main/resources/data/byg/recipes/acacia_sign_from_redwood_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:redwood_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/birch_sign_from_aspen_planks.json
+++ b/src/main/resources/data/byg/recipes/birch_sign_from_aspen_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:aspen_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:birch_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/birch_sign_from_cypress_planks.json
+++ b/src/main/resources/data/byg/recipes/birch_sign_from_cypress_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:cypress_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:birch_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/birch_sign_from_mangrove_planks.json
+++ b/src/main/resources/data/byg/recipes/birch_sign_from_mangrove_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:mangrove_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:birch_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/birch_sign_from_sythian_planks.json
+++ b/src/main/resources/data/byg/recipes/birch_sign_from_sythian_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:sythian_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:birch_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/blue_netherrack.json
+++ b/src/main/resources/data/byg/recipes/blue_netherrack.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:netherrack"
+    },
+    {
+      "item": "minecraft:warped_wart_block"
+    }
+  ],
+  "result": {
+    "item": "byg:blue_netherrack",
+    "count": 2
+  }
+}

--- a/src/main/resources/data/byg/recipes/compat/create/allium_flower_bush.json
+++ b/src/main/resources/data/byg/recipes/compat/create/allium_flower_bush.json
@@ -1,0 +1,31 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:allium_flower_bush"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:purple_dye",
+      "count": 3
+    },
+    {
+      "item": "minecraft:green_dye",
+      "count": 2,
+      "chance": 0.05
+    },
+    {
+      "item": "minecraft:magenta_dye",
+      "count": 2,
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/alpine_bellflower.json
+++ b/src/main/resources/data/byg/recipes/compat/create/alpine_bellflower.json
@@ -1,0 +1,30 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:alpine_bellflower"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:purple_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:blue_dye",
+      "count": 2,
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/amaranth.json
+++ b/src/main/resources/data/byg/recipes/compat/create/amaranth.json
@@ -1,0 +1,31 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:amaranth"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:red_dye",
+      "count": 3
+    },
+    {
+      "item": "minecraft:green_dye",
+      "count": 2,
+      "chance": 0.05
+    },
+    {
+      "item": "minecraft:red_dye",
+      "count": 2,
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/ametrine_ore.json
+++ b/src/main/resources/data/byg/recipes/compat/create/ametrine_ore.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "tag": "forge:ores/ametrine"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:ametrine_gems",
+      "count": 2
+    },
+    {
+      "item": "byg:ametrine_gems",
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 500
+}

--- a/src/main/resources/data/byg/recipes/compat/create/angelica.json
+++ b/src/main/resources/data/byg/recipes/compat/create/angelica.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:angelica"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:white_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/anthracite_ore.json
+++ b/src/main/resources/data/byg/recipes/compat/create/anthracite_ore.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "tag": "forge:ores/anthracite"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:anthracite",
+      "count": 2
+    },
+    {
+      "item": "byg:anthracite",
+      "chance": 0.5
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/azalea.json
+++ b/src/main/resources/data/byg/recipes/compat/create/azalea.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:azalea"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:blue_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:light_blue_dye",
+      "chance": 0.05
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/begonia.json
+++ b/src/main/resources/data/byg/recipes/compat/create/begonia.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:begonia"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:red_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/bistort.json
+++ b/src/main/resources/data/byg/recipes/compat/create/bistort.json
@@ -1,0 +1,30 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:bistort"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:pink_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:red_dye",
+      "count": 2,
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/black_rose.json
+++ b/src/main/resources/data/byg/recipes/compat/create/black_rose.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:black_rose"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:black_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:black_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/black_sand_from_crushing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/black_sand_from_crushing.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "minecraft:basalt"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:black_sand",
+      "count": 1
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/blue_glowcane_dust_from_block_crushing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/blue_glowcane_dust_from_block_crushing.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "byg:blue_glowcane_block"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:blue_glowcane_dust",
+      "count": 3
+    },
+    {
+      "item": "byg:blue_glowcane_dust",
+      "chance": 0.5
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/blue_glowcane_dust_from_milling.json
+++ b/src/main/resources/data/byg/recipes/compat/create/blue_glowcane_dust_from_milling.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:blue_glowcane"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:blue_glowcane_dust",
+      "count": 2
+    },
+    {
+      "item": "byg:blue_glowcane_dust",
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/blue_sage.json
+++ b/src/main/resources/data/byg/recipes/compat/create/blue_sage.json
@@ -1,0 +1,30 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:blue_sage"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:blue_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:cyan_dye",
+      "count": 2,
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/california_poppy.json
+++ b/src/main/resources/data/byg/recipes/compat/create/california_poppy.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:california_poppy"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:orange_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.05
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/cobbled_ether_stone_from_crushing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/cobbled_ether_stone_from_crushing.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "byg:ether_stone"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:cobbled_ether_stone",
+      "count": 1
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/crocus.json
+++ b/src/main/resources/data/byg/recipes/compat/create/crocus.json
@@ -1,0 +1,30 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:crocus"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:purple_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:magenta_dye",
+      "count": 2,
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/cyan_amaranth.json
+++ b/src/main/resources/data/byg/recipes/compat/create/cyan_amaranth.json
@@ -1,0 +1,31 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:cyan_amaranth"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:cyan_dye",
+      "count": 3
+    },
+    {
+      "item": "minecraft:green_dye",
+      "count": 2,
+      "chance": 0.05
+    },
+    {
+      "item": "minecraft:light_blue_dye",
+      "count": 2,
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/cyan_rose.json
+++ b/src/main/resources/data/byg/recipes/compat/create/cyan_rose.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:cyan_rose"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:cyan_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/cyan_tulip.json
+++ b/src/main/resources/data/byg/recipes/compat/create/cyan_tulip.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:cyan_tulip"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:cyan_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:lime_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/dacite_cobblestone_from_crushing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/dacite_cobblestone_from_crushing.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "byg:dacite"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:dacite_cobblestone",
+      "count": 1
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/dacite_from_compacting.json
+++ b/src/main/resources/data/byg/recipes/compat/create/dacite_from_compacting.json
@@ -1,0 +1,30 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:compacting",
+  "ingredients": [
+    {
+      "item": "minecraft:flint"
+    },
+    {
+      "item": "minecraft:flint"
+    },
+    {
+      "item": "byg:quartzite_sand"
+    },
+    {
+      "fluid": "minecraft:lava",
+      "nbt": {},
+      "amount": 100
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:dacite"
+    }
+  ]
+}

--- a/src/main/resources/data/byg/recipes/compat/create/daffodil.json
+++ b/src/main/resources/data/byg/recipes/compat/create/daffodil.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:daffodil"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:pink_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:magenta_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/delphinium.json
+++ b/src/main/resources/data/byg/recipes/compat/create/delphinium.json
@@ -1,0 +1,26 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:delphinium"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:blue_dye",
+      "count": 3
+    },
+    {
+      "item": "minecraft:blue_dye",
+      "count": 1,
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/end_sand_from_crushing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/end_sand_from_crushing.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "minecraft:end_stone"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:end_sand",
+      "count": 3
+    },
+    {
+      "item": "byg:end_sand",
+      "chance": 0.5
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/fairy_slipper.json
+++ b/src/main/resources/data/byg/recipes/compat/create/fairy_slipper.json
@@ -1,0 +1,30 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:fairy_slipper"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:magenta_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:pink_dye",
+      "count": 2,
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:yellow_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/firecracker_flower_bush.json
+++ b/src/main/resources/data/byg/recipes/compat/create/firecracker_flower_bush.json
@@ -1,0 +1,31 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:firecracker_flower_bush"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:pink_dye",
+      "count": 3
+    },
+    {
+      "item": "minecraft:green_dye",
+      "count": 2,
+      "chance": 0.05
+    },
+    {
+      "item": "minecraft:red_dye",
+      "count": 2,
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/foxglove.json
+++ b/src/main/resources/data/byg/recipes/compat/create/foxglove.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:foxglove"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:cyan_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:purple_dye",
+      "chance": 0.25
+    },
+    {
+      "item": "minecraft:light_gray_dye",
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/glowstone_dust_from_pervaded_netherrack_crushing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/glowstone_dust_from_pervaded_netherrack_crushing.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "byg:pervaded_netherrack"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:glowstone_dust",
+      "count": 2
+    },
+    {
+      "item": "minecraft:glowstone_dust",
+      "chance": 0.5
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/green_tulip.json
+++ b/src/main/resources/data/byg/recipes/compat/create/green_tulip.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:green_tulip"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:lime_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/guzmania.json
+++ b/src/main/resources/data/byg/recipes/compat/create/guzmania.json
@@ -1,0 +1,31 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:guzmania"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:orange_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:red_dye",
+      "count": 1,
+      "chance": 0.25
+    },
+    {
+      "item": "minecraft:green_dye",
+      "count": 1,
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/incan_lily.json
+++ b/src/main/resources/data/byg/recipes/compat/create/incan_lily.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:incan_lily"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:orange_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:red_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/iris.json
+++ b/src/main/resources/data/byg/recipes/compat/create/iris.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:iris"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:purple_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.05
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/japanese_orchid.json
+++ b/src/main/resources/data/byg/recipes/compat/create/japanese_orchid.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:japanese_orchid"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:pink_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:white_dye",
+      "chance": 0.05
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/kovan_flower.json
+++ b/src/main/resources/data/byg/recipes/compat/create/kovan_flower.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:kovan_flower"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:red_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:lime_dye",
+      "chance": 0.2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.05
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/lazarus_bellflower.json
+++ b/src/main/resources/data/byg/recipes/compat/create/lazarus_bellflower.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:lazarus_bellflower"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:magenta_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/lignite_ore.json
+++ b/src/main/resources/data/byg/recipes/compat/create/lignite_ore.json
@@ -1,0 +1,26 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "tag": "forge:ores/lignite"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:lignite",
+      "count": 2
+    },
+    {
+      "item": "byg:lignite",
+      "count": 2,
+      "chance": 0.5
+    }
+  ],
+  "processingTime": 300
+}

--- a/src/main/resources/data/byg/recipes/compat/create/lolipop_flower.json
+++ b/src/main/resources/data/byg/recipes/compat/create/lolipop_flower.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:lolipop_flower"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:yellow_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:yellow_dye",
+      "chance": 0.25
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.05
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/magenta_amaranth.json
+++ b/src/main/resources/data/byg/recipes/compat/create/magenta_amaranth.json
@@ -1,0 +1,31 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:magenta_amaranth"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:magenta_dye",
+      "count": 3
+    },
+    {
+      "item": "minecraft:green_dye",
+      "count": 2,
+      "chance": 0.05
+    },
+    {
+      "item": "minecraft:magenta_dye",
+      "count": 2,
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/magenta_tulip.json
+++ b/src/main/resources/data/byg/recipes/compat/create/magenta_tulip.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:magenta_tulip"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:magenta_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:lime_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/meadow_grass_from_filling.json
+++ b/src/main/resources/data/byg/recipes/compat/create/meadow_grass_from_filling.json
@@ -1,0 +1,24 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:filling",
+  "ingredients": [
+    {
+      "item": "byg:meadow_dirt"
+    },
+    {
+      "fluid": "minecraft:water",
+      "nbt": {},
+      "amount": 500
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:meadow_grass_block"
+    }
+  ]
+}

--- a/src/main/resources/data/byg/recipes/compat/create/meadow_path_from_pressing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/meadow_path_from_pressing.json
@@ -1,0 +1,24 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:pressing",
+  "ingredients": [
+    [
+      {
+        "item": "byg:meadow_grass_block"
+      },
+      {
+        "item": "byg:meadow_dirt"
+      }
+    ]
+  ],
+  "results": [
+    {
+      "item": "byg:meadow_grass_path"
+    }
+  ]
+}

--- a/src/main/resources/data/byg/recipes/compat/create/obsidian_from_cryptic_magma_block_splashing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/obsidian_from_cryptic_magma_block_splashing.json
@@ -1,0 +1,19 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:splashing",
+  "ingredients": [
+    {
+      "item": "byg:cryptic_magma_block"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:obsidian"
+    }
+  ]
+}

--- a/src/main/resources/data/byg/recipes/compat/create/orange_amaranth.json
+++ b/src/main/resources/data/byg/recipes/compat/create/orange_amaranth.json
@@ -1,0 +1,31 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:orange_amaranth"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:orange_dye",
+      "count": 3
+    },
+    {
+      "item": "minecraft:green_dye",
+      "count": 2,
+      "chance": 0.05
+    },
+    {
+      "item": "minecraft:orange_dye",
+      "count": 2,
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/orange_daisy.json
+++ b/src/main/resources/data/byg/recipes/compat/create/orange_daisy.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:orange_daisy"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:orange_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:yellow_dye",
+      "chance": 0.2
+    },
+    {
+      "item": "minecraft:lime_dye",
+      "chance": 0.05
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/osiria_rose.json
+++ b/src/main/resources/data/byg/recipes/compat/create/osiria_rose.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:osiria_rose"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:pink_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.05
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/peach_leather_flower.json
+++ b/src/main/resources/data/byg/recipes/compat/create/peach_leather_flower.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:peach_leather_flower"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:pink_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/pink_allium.json
+++ b/src/main/resources/data/byg/recipes/compat/create/pink_allium.json
@@ -1,0 +1,30 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:pink_allium"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:magenta_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:pink_dye",
+      "count": 2,
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:purple_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/pink_allium_flower_bush.json
+++ b/src/main/resources/data/byg/recipes/compat/create/pink_allium_flower_bush.json
@@ -1,0 +1,31 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:pink_allium_flower_bush"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:pink_dye",
+      "count": 3
+    },
+    {
+      "item": "minecraft:green_dye",
+      "count": 2,
+      "chance": 0.05
+    },
+    {
+      "item": "minecraft:magenta_dye",
+      "count": 2,
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/pink_anemone.json
+++ b/src/main/resources/data/byg/recipes/compat/create/pink_anemone.json
@@ -1,0 +1,26 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:pink_anemone"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:pink_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:purple_dye",
+      "count": 2,
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/pink_daffodil.json
+++ b/src/main/resources/data/byg/recipes/compat/create/pink_daffodil.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:pink_daffodil"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:pink_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:white_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/pink_glowcane_dust_from_block_crushing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/pink_glowcane_dust_from_block_crushing.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "byg:pink_glowcane_block"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:pink_glowcane_dust",
+      "count": 3
+    },
+    {
+      "item": "byg:pink_glowcane_dust",
+      "chance": 0.5
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/pink_glowcane_dust_from_milling.json
+++ b/src/main/resources/data/byg/recipes/compat/create/pink_glowcane_dust_from_milling.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:pink_glowcane"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:pink_glowcane_dust",
+      "count": 2
+    },
+    {
+      "item": "byg:pink_glowcane_dust",
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/pink_orchid.json
+++ b/src/main/resources/data/byg/recipes/compat/create/pink_orchid.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:pink_orchid"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:pink_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:magenta_dye",
+      "chance": 0.05
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/pink_sand_from_crushing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/pink_sand_from_crushing.json
@@ -1,0 +1,30 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    [
+      {
+        "item": "minecraft:brain_coral"
+      },
+      {
+        "item": "minecraft:brain_coral_fan"
+      },
+      {
+        "item": "minecraft:bubble_coral"
+      },
+      {
+        "item": "minecraft:bubble_coral_fan"
+      }
+    ]
+  ],
+  "results": [
+    {
+      "item": "byg:pink_sand"
+    }
+  ]
+}

--- a/src/main/resources/data/byg/recipes/compat/create/protea_flower.json
+++ b/src/main/resources/data/byg/recipes/compat/create/protea_flower.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:protea_flower"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:magenta_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:lime_dye",
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:purple_dye",
+      "count": 0.05
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/purple_amaranth.json
+++ b/src/main/resources/data/byg/recipes/compat/create/purple_amaranth.json
@@ -1,0 +1,31 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:purple_amaranth"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:purple_dye",
+      "count": 3
+    },
+    {
+      "item": "minecraft:green_dye",
+      "count": 2,
+      "chance": 0.05
+    },
+    {
+      "item": "minecraft:purple_dye",
+      "count": 2,
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/purple_glowcane_dust_from_block_crushing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/purple_glowcane_dust_from_block_crushing.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "byg:purple_glowcane_block"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:purple_glowcane_dust",
+      "count": 3
+    },
+    {
+      "item": "byg:purple_glowcane_dust",
+      "chance": 0.5
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/purple_glowcane_dust_from_milling.json
+++ b/src/main/resources/data/byg/recipes/compat/create/purple_glowcane_dust_from_milling.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:purple_glowcane"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:purple_glowcane_dust",
+      "count": 2
+    },
+    {
+      "item": "byg:purple_glowcane_dust",
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/purple_orchid.json
+++ b/src/main/resources/data/byg/recipes/compat/create/purple_orchid.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:purple_orchid"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:purple_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:purple_dye",
+      "chance": 0.05
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/purple_sage.json
+++ b/src/main/resources/data/byg/recipes/compat/create/purple_sage.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:purple_sage"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:purple_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:magenta_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/purple_tulip.json
+++ b/src/main/resources/data/byg/recipes/compat/create/purple_tulip.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:purple_tulip"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:purple_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:lime_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/quartzite_sand_from_flint.json
+++ b/src/main/resources/data/byg/recipes/compat/create/quartzite_sand_from_flint.json
@@ -1,0 +1,22 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:mixing",
+  "ingredients": [
+    {
+      "tag": "forge:sand/colorless"
+    },
+    {
+      "item": "minecraft:flint"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:quartzite_sand"
+    }
+  ]
+}

--- a/src/main/resources/data/byg/recipes/compat/create/red_cornflower.json
+++ b/src/main/resources/data/byg/recipes/compat/create/red_cornflower.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:red_cornflower"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:red_dye",
+      "count": 2
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/red_glowcane_dust_from_block_crushing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/red_glowcane_dust_from_block_crushing.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "byg:red_glowcane_block"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:red_glowcane_dust",
+      "count": 3
+    },
+    {
+      "item": "byg:red_glowcane_dust",
+      "chance": 0.5
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/red_glowcane_dust_from_milling.json
+++ b/src/main/resources/data/byg/recipes/compat/create/red_glowcane_dust_from_milling.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:red_glowcane"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:red_glowcane_dust",
+      "count": 2
+    },
+    {
+      "item": "byg:red_glowcane_dust",
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/red_orchid.json
+++ b/src/main/resources/data/byg/recipes/compat/create/red_orchid.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:red_orchid"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:red_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:orange_dye",
+      "chance": 0.05
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/richea.json
+++ b/src/main/resources/data/byg/recipes/compat/create/richea.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:richea"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:light_gray_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:brown_dye",
+      "chance": 0.05
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/rose.json
+++ b/src/main/resources/data/byg/recipes/compat/create/rose.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:rose"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:red_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/scoria_cobblestone_from_crushing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/scoria_cobblestone_from_crushing.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "byg:scoria_stone"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:scoria_cobblestone",
+      "count": 1
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/silver_vase_flower.json
+++ b/src/main/resources/data/byg/recipes/compat/create/silver_vase_flower.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:silver_vase_flower"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:pink_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:white_dye",
+      "chance": 0.05
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/snowdrops.json
+++ b/src/main/resources/data/byg/recipes/compat/create/snowdrops.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:snowdrops"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:white_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:lime_dye",
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:white_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/tall_allium.json
+++ b/src/main/resources/data/byg/recipes/compat/create/tall_allium.json
@@ -1,0 +1,31 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:tall_allium"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:purple_dye",
+      "count": 3
+    },
+    {
+      "item": "minecraft:purple_dye",
+      "count": 2,
+      "chance": 0.05
+    },
+    {
+      "item": "minecraft:magenta_dye",
+      "count": 2,
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/tall_pink_allium.json
+++ b/src/main/resources/data/byg/recipes/compat/create/tall_pink_allium.json
@@ -1,0 +1,31 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:tall_pink_allium"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:pink_dye",
+      "count": 3
+    },
+    {
+      "item": "minecraft:pink_dye",
+      "count": 2,
+      "chance": 0.05
+    },
+    {
+      "item": "minecraft:magenta_dye",
+      "count": 2,
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/torch_ginger.json
+++ b/src/main/resources/data/byg/recipes/compat/create/torch_ginger.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:torch_ginger"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:red_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/violet_leather_flower.json
+++ b/src/main/resources/data/byg/recipes/compat/create/violet_leather_flower.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:violet_leather_flower"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:blue_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/white_anemone.json
+++ b/src/main/resources/data/byg/recipes/compat/create/white_anemone.json
@@ -1,0 +1,26 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:white_anemone"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:white_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:light_gray_dye",
+      "count": 2,
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/white_sage.json
+++ b/src/main/resources/data/byg/recipes/compat/create/white_sage.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:white_sage"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:white_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:gray_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/white_sand_from_crushing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/white_sand_from_crushing.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "byg:quartzite_sand"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:white_sand",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/winter_cyclamen.json
+++ b/src/main/resources/data/byg/recipes/compat/create/winter_cyclamen.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:winter_cyclamen"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:cyan_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/winter_rose.json
+++ b/src/main/resources/data/byg/recipes/compat/create/winter_rose.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:winter_rose"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:white_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/winter_scilla.json
+++ b/src/main/resources/data/byg/recipes/compat/create/winter_scilla.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:winter_scilla"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:light_blue_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/yellow_daffodil.json
+++ b/src/main/resources/data/byg/recipes/compat/create/yellow_daffodil.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:yellow_daffodil"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:yellow_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:green_dye",
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:pink_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/create/yellow_tulip.json
+++ b/src/main/resources/data/byg/recipes/compat/create/yellow_tulip.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "byg:yellow_tulip"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:yellow_dye",
+      "count": 2
+    },
+    {
+      "item": "minecraft:lime_dye",
+      "chance": 0.1
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/byg/recipes/compat/tconstruct/cryptic_magma_block_from_casting.json
+++ b/src/main/resources/data/byg/recipes/compat/tconstruct/cryptic_magma_block_from_casting.json
@@ -1,0 +1,19 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "tconstruct"
+    }
+  ],
+  "type": "tconstruct:casting_basin",
+  "cast": {
+    "item": "byg:cryptic_stone"
+  },
+  "cast_consumed": true,
+  "fluid": {
+    "name": "tconstruct:magma_cream",
+    "amount": 1000
+  },
+  "result": "byg:cryptic_magma_block",
+  "cooling_time": 90
+}

--- a/src/main/resources/data/byg/recipes/compat/tconstruct/glowstone_lantern.json
+++ b/src/main/resources/data/byg/recipes/compat/tconstruct/glowstone_lantern.json
@@ -1,0 +1,19 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "tconstruct"
+    }
+  ],
+  "type": "tconstruct:casting_table",
+  "cast": {
+    "item": "minecraft:glowstone_dust"
+  },
+  "cast_consumed": true,
+  "fluid": {
+    "name": "tconstruct:molten_iron",
+    "amount": 128
+  },
+  "result": "byg:glowstone_lantern",
+  "cooling_time": 57
+}

--- a/src/main/resources/data/byg/recipes/compat/tconstruct/magma_cream_from_cryptic_magma_block_melting.json
+++ b/src/main/resources/data/byg/recipes/compat/tconstruct/magma_cream_from_cryptic_magma_block_melting.json
@@ -1,0 +1,18 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "tconstruct"
+    }
+  ],
+  "type": "tconstruct:melting",
+  "ingredient": {
+    "item": "byg:cryptic_magma_block"
+  },
+  "result": {
+    "fluid": "tconstruct:magma_cream",
+    "amount": 1000
+  },
+  "temperature": 300,
+  "time": 127
+}

--- a/src/main/resources/data/byg/recipes/compat/tconstruct/magma_cream_from_magmatic_stone_melting.json
+++ b/src/main/resources/data/byg/recipes/compat/tconstruct/magma_cream_from_magmatic_stone_melting.json
@@ -1,0 +1,18 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "tconstruct"
+    }
+  ],
+  "type": "tconstruct:melting",
+  "ingredient": {
+    "item": "byg:magmatic_stone"
+  },
+  "result": {
+    "fluid": "tconstruct:magma_cream",
+    "amount": 1000
+  },
+  "temperature": 300,
+  "time": 127
+}

--- a/src/main/resources/data/byg/recipes/compat/tconstruct/magmatic_stone_from_casting.json
+++ b/src/main/resources/data/byg/recipes/compat/tconstruct/magmatic_stone_from_casting.json
@@ -1,0 +1,19 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "tconstruct"
+    }
+  ],
+  "type": "tconstruct:casting_basin",
+  "cast": {
+    "item": "minecraft:blackstone"
+  },
+  "cast_consumed": true,
+  "fluid": {
+    "name": "tconstruct:magma_cream",
+    "amount": 1000
+  },
+  "result": "byg:magmatic_stone",
+  "cooling_time": 90
+}

--- a/src/main/resources/data/byg/recipes/compat/tconstruct/therium_lantern.json
+++ b/src/main/resources/data/byg/recipes/compat/tconstruct/therium_lantern.json
@@ -1,0 +1,19 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "tconstruct"
+    }
+  ],
+  "type": "tconstruct:casting_table",
+  "cast": {
+    "item": "byg:therium_shard"
+  },
+  "cast_consumed": true,
+  "fluid": {
+    "name": "tconstruct:molten_iron",
+    "amount": 128
+  },
+  "result": "byg:therium_lantern",
+  "cooling_time": 57
+}

--- a/src/main/resources/data/byg/recipes/crimson_sign_from_bulbis_planks.json
+++ b/src/main/resources/data/byg/recipes/crimson_sign_from_bulbis_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:bulbis_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:crimson_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/crimson_sign_from_cherry_planks.json
+++ b/src/main/resources/data/byg/recipes/crimson_sign_from_cherry_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:cherry_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:crimson_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/dark_oak_sign_from_ebony_planks.json
+++ b/src/main/resources/data/byg/recipes/dark_oak_sign_from_ebony_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:ebony_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:dark_oak_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/embur_gel_ball.json
+++ b/src/main/resources/data/byg/recipes/embur_gel_ball.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "byg:embur_gel_block"
+    }
+  ],
+  "result": {
+    "item": "byg:embur_gel_ball",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/byg/recipes/jungle_sign_from_jacaranda_planks.json
+++ b/src/main/resources/data/byg/recipes/jungle_sign_from_jacaranda_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:jacaranda_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:jungle_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/jungle_sign_from_mahogany_planks.json
+++ b/src/main/resources/data/byg/recipes/jungle_sign_from_mahogany_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:mahogany_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:jungle_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/jungle_sign_from_nightshade_planks.json
+++ b/src/main/resources/data/byg/recipes/jungle_sign_from_nightshade_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:nightshade_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:jungle_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/jungle_sign_from_zelkova_planks.json
+++ b/src/main/resources/data/byg/recipes/jungle_sign_from_zelkova_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:zelkova_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:jungle_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/mossy_netherrack.json
+++ b/src/main/resources/data/byg/recipes/mossy_netherrack.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:netherrack"
+    },
+    {
+      "item": "minecraft:vine"
+    }
+  ],
+  "result": {
+    "item": "byg:mossy_netherrack"
+  }
+}

--- a/src/main/resources/data/byg/recipes/oak_sign_from_fir_planks.json
+++ b/src/main/resources/data/byg/recipes/oak_sign_from_fir_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:fir_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/oak_sign_from_holly_planks.json
+++ b/src/main/resources/data/byg/recipes/oak_sign_from_holly_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:holly_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/oak_sign_from_pine_planks.json
+++ b/src/main/resources/data/byg/recipes/oak_sign_from_pine_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:pine_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/oak_sign_from_rainbow_eucalyptus_planks.json
+++ b/src/main/resources/data/byg/recipes/oak_sign_from_rainbow_eucalyptus_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:rainbow_eucalyptus_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/oak_sign_from_willow_planks.json
+++ b/src/main/resources/data/byg/recipes/oak_sign_from_willow_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:willow_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/quartzite_sand.json
+++ b/src/main/resources/data/byg/recipes/quartzite_sand.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "forge:sand/colorless"
+    },
+    {
+      "item": "minecraft:quartz"
+    }
+  ],
+  "result": {
+    "item": "byg:quartzite_sand",
+    "count": 1
+  }
+}

--- a/src/main/resources/data/byg/recipes/redstone_from_cryptic_redstone_ore.json
+++ b/src/main/resources/data/byg/recipes/redstone_from_cryptic_redstone_ore.json
@@ -1,0 +1,10 @@
+{
+	"type": "minecraft:smelting",
+	"ingredient":
+	{
+		"item": "byg:cryptic_redstone_ore"
+	},
+	"result": "minecraft:redstone",
+	"experience": 0.7,
+	"cookingtime": 200
+}

--- a/src/main/resources/data/byg/recipes/redstone_from_cryptic_redstone_ore_blasting.json
+++ b/src/main/resources/data/byg/recipes/redstone_from_cryptic_redstone_ore_blasting.json
@@ -1,0 +1,10 @@
+{
+	"type": "minecraft:blasting",
+	"ingredient":
+	{
+		"item": "byg:cryptic_redstone_ore"
+	},
+	"result": "minecraft:redstone",
+	"experience": 0.7,
+	"cookingtime": 100
+}

--- a/src/main/resources/data/byg/recipes/spruce_sign_from_embur_planks.json
+++ b/src/main/resources/data/byg/recipes/spruce_sign_from_embur_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:embur_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:spruce_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/warped_sign_from_blue_enchanted_planks.json
+++ b/src/main/resources/data/byg/recipes/warped_sign_from_blue_enchanted_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:blue_enchanted_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/warped_sign_from_ether_planks.json
+++ b/src/main/resources/data/byg/recipes/warped_sign_from_ether_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:ether_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/warped_sign_from_green_enchanted_planks.json
+++ b/src/main/resources/data/byg/recipes/warped_sign_from_green_enchanted_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:green_enchanted_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/warped_sign_from_imparius_planks.json
+++ b/src/main/resources/data/byg/recipes/warped_sign_from_imparius_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:lament_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/warped_sign_from_skyris_planks.json
+++ b/src/main/resources/data/byg/recipes/warped_sign_from_skyris_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:skyris_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/byg/recipes/warped_sign_from_witch_hazel_planks.json
+++ b/src/main/resources/data/byg/recipes/warped_sign_from_witch_hazel_planks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    " X "
+  ],
+  "key": {
+    "#": {
+      "item": "byg:witch_hazel_planks"
+    },
+    "X": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_sign",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/ametrine.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/ametrine.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "byg:ametrine_ore",
+    "byg:budding_ametrine_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/anthracite.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/anthracite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:anthracite_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/lignite.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/lignite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:lignite_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/pendorite.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/pendorite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:pendorite_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/redstone.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/redstone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:cryptic_redstone_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/sand/black.json
+++ b/src/main/resources/data/forge/tags/blocks/sand/black.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:black_sand"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/sand/blue.json
+++ b/src/main/resources/data/forge/tags/blocks/sand/blue.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:blue_sand"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/sand/colorless.json
+++ b/src/main/resources/data/forge/tags/blocks/sand/colorless.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:end_sand"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/sand/pink.json
+++ b/src/main/resources/data/forge/tags/blocks/sand/pink.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:pink_sand"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/sand/purple.json
+++ b/src/main/resources/data/forge/tags/blocks/sand/purple.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:purple_sand"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/sand/white.json
+++ b/src/main/resources/data/forge/tags/blocks/sand/white.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:white_sand"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/ametrine.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/ametrine.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:ametrine_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/anthracite.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/anthracite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:anthracite_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/lignite.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/lignite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:lignite_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/pendorite.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/pendorite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:pendorite_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/gems/ametrine.json
+++ b/src/main/resources/data/forge/tags/items/gems/ametrine.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:ametrine_gems"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/ametrine.json
+++ b/src/main/resources/data/forge/tags/items/ores/ametrine.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "byg:ametrine_ore",
+    "byg:budding_ametrine_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/anthracite.json
+++ b/src/main/resources/data/forge/tags/items/ores/anthracite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:anthracite_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/lignite.json
+++ b/src/main/resources/data/forge/tags/items/ores/lignite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:lignite_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/pendorite.json
+++ b/src/main/resources/data/forge/tags/items/ores/pendorite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:pendorite_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/redstone.json
+++ b/src/main/resources/data/forge/tags/items/ores/redstone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:cryptic_redstone_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/sand/black.json
+++ b/src/main/resources/data/forge/tags/items/sand/black.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:black_sand"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/sand/blue.json
+++ b/src/main/resources/data/forge/tags/items/sand/blue.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:blue_sand"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/sand/colorless.json
+++ b/src/main/resources/data/forge/tags/items/sand/colorless.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:end_sand"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/sand/pink.json
+++ b/src/main/resources/data/forge/tags/items/sand/pink.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:pink_sand"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/sand/purple.json
+++ b/src/main/resources/data/forge/tags/items/sand/purple.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:purple_sand"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/sand/white.json
+++ b/src/main/resources/data/forge/tags/items/sand/white.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:white_sand"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/ametrine.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/ametrine.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:ametrine_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/anthracite.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/anthracite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:anthracite_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/lignite.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/lignite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:lignite_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/pendorite.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/pendorite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "byg:pendorite_block"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/sand.json
+++ b/src/main/resources/data/minecraft/tags/items/sand.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "byg:black_sand",
+    "byg:blue_sand",
+    "byg:end_sand",
+    "byg:pink_sand",
+    "byg:purple_sand",
+    "byg:white_sand"
+  ]
+}


### PR DESCRIPTION
Most notable changes:
- Signs can be made from the various wood types, workaround for #348
- The following items are craftable with appropriate recipes: blue netherrack, embur gel ball, mossy netherrack and quartzite sand
- Glowstone lanterns, therium lanterns, cryptic magma blocks and magmatic stone can be casted in a TConstruct smeltery
- Glowcane and ores can be crushed in a Create crusher to produce reliable amounts of their material
- Flowers can be crushed in a Create millstone to produce more of their dyes
- Dacite is given a renewable recipe, matching other Create stone recipes

There are a few additional minor changes as well, I'd be happy to make any adjustments as needed.