### PR TITLE
Some minor recipe tweaks

### DIFF
--- a/src/main/resources/data/byg/recipes/blue_sand.json
+++ b/src/main/resources/data/byg/recipes/blue_sand.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "forge:sand/colorless"
+    },
+    {
+      "tag": "forge:gems/lapis"
+    }
+  ],
+  "result": {
+    "item": "byg:blue_sand",
+    "count": 1
+  }
+}

--- a/src/main/resources/data/byg/recipes/compat/create/ametrine_horse_armor.json
+++ b/src/main/resources/data/byg/recipes/compat/create/ametrine_horse_armor.json
@@ -1,0 +1,35 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "byg:ametrine_horse_armor"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:ametrine_gems"
+    },
+    {
+      "item": "minecraft:leather",
+      "count": 2,
+      "chance": 0.5
+    },
+    {
+      "item": "byg:ametrine_gems",
+      "count": 3,
+      "chance": 0.1
+    },
+    {
+      "item": "minecraft:string",
+      "count": 2,
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 200
+}

--- a/src/main/resources/data/byg/recipes/compat/create/aspen_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/aspen_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:aspen_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_aspen_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/baobab_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/baobab_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:baobab_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_baobab_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/blue_enchanted_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/blue_enchanted_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:blue_enchanted_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_blue_enchanted_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/bulbis_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/bulbis_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:bulbis_stem"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_bulbis_stem",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/cherry_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/cherry_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:cherry_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_cherry_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/cika_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/cika_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:cika_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_cika_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/cypress_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/cypress_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:cypress_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_cypress_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/ebony_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/ebony_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:ebony_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_ebony_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/embur_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/embur_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:embur_pedu"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_embur_pedu",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/ether_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/ether_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:ether_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_ether_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/fir_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/fir_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:fir_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_fir_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/green_enchanted_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/green_enchanted_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:green_enchanted_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_green_enchanted_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/holly_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/holly_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:holly_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_holly_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/jacaranda_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/jacaranda_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:jacaranda_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_jacaranda_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/lament_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/lament_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:lament_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_lament_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/mahogany_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/mahogany_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:mahogany_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_mahogany_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/mangrove_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/mangrove_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:mangrove_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_mangrove_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/maple_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/maple_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:maple_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_maple_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/nightshade_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/nightshade_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:nightshade_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_nightshade_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/palm_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/palm_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:palm_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_palm_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/palo_verde_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/palo_verde_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:palo_verde_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_palo_verde_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/pendorite_horse_armor.json
+++ b/src/main/resources/data/byg/recipes/compat/create/pendorite_horse_armor.json
@@ -1,0 +1,26 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "byg:pendorite_horse_armor"
+    }
+  ],
+  "results": [
+    {
+      "item": "byg:pendorite_scraps",
+      "count": 2
+    },
+    {
+      "item": "byg:pendorite_scraps",
+      "count": 2,
+      "chance": 0.5
+    }
+  ],
+  "processingTime": 200
+}

--- a/src/main/resources/data/byg/recipes/compat/create/pine_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/pine_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:pine_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_pine_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/protea_flower.json
+++ b/src/main/resources/data/byg/recipes/compat/create/protea_flower.json
@@ -22,7 +22,7 @@
     },
     {
       "item": "minecraft:purple_dye",
-      "count": 0.05
+      "chance": 0.05
     }
   ],
   "processingTime": 50

--- a/src/main/resources/data/byg/recipes/compat/create/rainbow_eucalyptus_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/rainbow_eucalyptus_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:rainbow_eucalyptus_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_rainbow_eucalyptus_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/red_rock_from_compacting.json
+++ b/src/main/resources/data/byg/recipes/compat/create/red_rock_from_compacting.json
@@ -5,16 +5,16 @@
       "modid": "create"
     }
   ],
-  "type": "create:mixing",
+  "type": "create:compacting",
   "ingredients": [
     {
-      "item": "minecraft:flint"
+      "item": "minecraft:clay_ball"
     },
     {
-      "item": "minecraft:flint"
+      "item": "minecraft:clay_ball"
     },
     {
-      "tag": "forge:sand/colorless"
+      "tag": "forge:sand/red"
     },
     {
       "fluid": "minecraft:lava",
@@ -24,7 +24,7 @@
   ],
   "results": [
     {
-      "item": "byg:quartzite_sand"
+      "item": "byg:red_rock"
     }
   ]
 }

--- a/src/main/resources/data/byg/recipes/compat/create/red_sand_from_red_rock_crushing.json
+++ b/src/main/resources/data/byg/recipes/compat/create/red_sand_from_red_rock_crushing.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "byg:red_rock"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:red_sand",
+      "count": 1
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/byg/recipes/compat/create/redwood_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/redwood_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:redwood_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_redwood_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/skyris_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/skyris_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:skyris_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_skyris_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_aspen_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_aspen_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_aspen_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:aspen_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_baobab_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_baobab_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_baobab_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:baobab_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_blue_enchanted_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_blue_enchanted_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_blue_enchanted_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:blue_enchanted_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_bulbis_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_bulbis_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_bulbis_stem"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:bulbis_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_cherry_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_cherry_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_cherry_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:cherry_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_cika_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_cika_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_cika_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:cika_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_cypress_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_cypress_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_cypress_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:cypress_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_ebony_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_ebony_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_ebony_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:ebony_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_embur_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_embur_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_embur_pedu"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:embur_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_ether_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_ether_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_ether_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:ether_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_fir_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_fir_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_fir_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:fir_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_green_enchanted_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_green_enchanted_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_green_enchanted_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:green_enchanted_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_holly_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_holly_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_holly_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:holly_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_jacaranda_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_jacaranda_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_jacaranda_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:jacaranda_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_lament_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_lament_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_lament_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:lament_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_mahogany_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_mahogany_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_mahogany_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:mahogany_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_mangrove_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_mangrove_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_mangrove_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:mangrove_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_maple_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_maple_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_maple_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:maple_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_nightshade_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_nightshade_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_nightshade_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:nightshade_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_palm_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_palm_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_palm_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:palm_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_palo_verde_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_palo_verde_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_palo_verde_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "minecraft:birch_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_pine_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_pine_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_pine_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:pine_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_rainbow_eucalyptus_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_rainbow_eucalyptus_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_rainbow_eucalyptus_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:rainbow_eucalyptus_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_redwood_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_redwood_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_redwood_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:redwood_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_skyris_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_skyris_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_skyris_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:skyris_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_sythian_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_sythian_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_sythian_stem"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:sythian_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_willow_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_willow_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_willow_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:willow_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_witch_hazel_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_witch_hazel_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_witch_hazel_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:witch_hazel_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/stripped_zelkova_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/stripped_zelkova_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:stripped_zelkova_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:zelkova_planks",
+      "count": 5
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/sythian_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/sythian_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:sythian_stem"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_sythian_stem",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/willow_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/willow_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:willow_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_willow_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/witch_hazel_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/witch_hazel_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:witch_hazel_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_witch_hazel_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/compat/create/zelkova_log.json
+++ b/src/main/resources/data/byg/recipes/compat/create/zelkova_log.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+      {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "byg:zelkova_log"
+    }
+  ], 
+  "results": [
+    {
+      "item": "byg:stripped_zelkova_log",
+      "count": 1
+    }
+  ],
+  "processingTime": 100
+}

--- a/src/main/resources/data/byg/recipes/dacite_from_andesite.json
+++ b/src/main/resources/data/byg/recipes/dacite_from_andesite.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "AQ",
+    "QA"
+  ],
+  "key": {
+    "Q": {
+      "item": "minecraft:quartz"
+    },
+    "A": {
+      "item": "minecraft:andesite"
+    }
+  },
+  "result": {
+    "item": "byg:dacite",
+    "count": 2
+  }
+}

--- a/src/main/resources/data/byg/recipes/mud_ball.json
+++ b/src/main/resources/data/byg/recipes/mud_ball.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "byg:mud_block"
+    }
+  ],
+  "result": {
+    "item": "byg:mud_ball",
+    "count": 4
+  }
+}

--- a/src/main/resources/data/byg/recipes/mud_block_from_dirt.json
+++ b/src/main/resources/data/byg/recipes/mud_block_from_dirt.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:dirt"
+    },
+    {
+      "item": "minecraft:water_bucket"
+    }
+  ],
+  "result": {
+    "item": "byg:mud_block",
+    "count": 1
+  }
+}

--- a/src/main/resources/data/byg/recipes/red_rock_from_terracotta.json
+++ b/src/main/resources/data/byg/recipes/red_rock_from_terracotta.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:terracotta"
+    },
+    {
+      "tag": "forge:cobblestone"
+    }
+  ],
+  "result": {
+    "item": "byg:red_rock",
+    "count": 2
+  }
+}

--- a/src/main/resources/data/byg/recipes/scoria_from_basalt.json
+++ b/src/main/resources/data/byg/recipes/scoria_from_basalt.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:basalt"
+    },
+    {
+      "item": "minecraft:andesite"
+    }
+  ],
+  "result": {
+    "item": "byg:scoria_stone",
+    "count": 2
+  }
+}

--- a/src/main/resources/data/byg/recipes/soapstone_from_clay.json
+++ b/src/main/resources/data/byg/recipes/soapstone_from_clay.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "forge:cobblestone"
+    },
+    {
+      "item": "minecraft:clay_ball"
+    }
+  ],
+  "result": {
+    "item": "byg:soapstone",
+    "count": 1
+  }
+}


### PR DESCRIPTION
- Fix protea flower crushing recipe
- Add crushing recipes for ametrine and pendorite horse armor
- Make blue sand craftable with a block of sand and one lapis lazuli
- Adjust quartzite sand mixing recipe to be more balanced
- Dacite, soapstone, red rock and scoria stone are given crafting recipes, inspired by #382 
- Mud block can be crafted with one block of dirt and a bucket of water, and a mud block can be crafted into 4 mud balls
- Add support for cutting logs with Create's mechanical saw