### PR TITLE
Added second check to buildTrunk method

### DIFF
--- a/src/main/java/corgiaoc/byg/common/world/feature/overworld/trees/util/BYGAbstractTreeFeature.java
+++ b/src/main/java/corgiaoc/byg/common/world/feature/overworld/trees/util/BYGAbstractTreeFeature.java
@@ -459,6 +459,7 @@ public abstract class BYGAbstractTreeFeature<TFC extends BYGTreeConfig> extends 
                 if (!FeatureUtil.isTerrainOrRock(reader, mutable)) {
                     reader.setBlock(mutable, config.getTrunkProvider().getState(random, mutable), 2);
                 }
+                else break;
             }
             mutable.move(Direction.DOWN);
         }

--- a/src/main/java/corgiaoc/byg/common/world/feature/overworld/trees/util/BYGAbstractTreeFeature.java
+++ b/src/main/java/corgiaoc/byg/common/world/feature/overworld/trees/util/BYGAbstractTreeFeature.java
@@ -550,7 +550,7 @@ public abstract class BYGAbstractTreeFeature<TFC extends BYGTreeConfig> extends 
             for (BlockPos blockPos : set) {
                 if (blockPos.getY() == pos.getY()) {
                     boolean cliff = isCliff(worldIn, 9, blockPos);
-                    if (!cliff) {
+                    if (!cliff && FeatureUtil.isAir(worldIn, blockPos.below())) {
                         this.buildTrunk(worldIn, config, rand, blockPos, 10);
                     }
                 }


### PR DESCRIPTION
`isCliff()` will still pass if there are solid blocks below. Currently it just checks if there is a solid block within the "down range" which immediately finds the block below marking it as a cliff, which calls `buildTrunk()`. This is a second check to make sure the block below the starting trunk is air (can change to check for air / water, not sure what functionality you wanted there).