### PR TITLE
feat: add End Biomes to BiomeDictionary

### DIFF
--- a/src/main/java/corgiaoc/byg/core/world/BYGBiomes.java
+++ b/src/main/java/corgiaoc/byg/core/world/BYGBiomes.java
@@ -344,8 +344,17 @@ public class BYGBiomes {
             BiomeDictionary.addTypes(RegistryKey.create(Registry.BIOME_REGISTRY, WorldGenRegistries.BIOME.getKey(bygSubBiome.getBiome())), bygSubBiome.getDictionaryTypes());
         }
 
-        for (BYGNetherBiome bygNetherBiome : BYGNetherBiome.BYG_NETHER_BIOMES)
+        for (BYGNetherBiome bygNetherBiome : BYGNetherBiome.BYG_NETHER_BIOMES) {
             BiomeDictionary.addTypes(bygNetherBiome.getKey(), bygNetherBiome.getBiomeDictionary());
+        }
+
+        for (BYGEndBiome bygEndBiome : BYGEndBiome.BYG_END_BIOMES) {
+            BiomeDictionary.addTypes(bygEndBiome.getKey(), bygEndBiome.getBiomeDictionary());
+        }
+
+        for (BYGEndSubBiome bygEndSubBiome : BYGEndSubBiome.BYG_END_SUB_BIOMES) {
+            BiomeDictionary.addTypes(bygEndSubBiome.getKey(), bygEndSubBiome.getBiomeDictionary());
+        }
     }
 
     //used in MixinMinecraftServer

--- a/src/main/resources/byg.mixins.json
+++ b/src/main/resources/byg.mixins.json
@@ -28,9 +28,7 @@
     "server.MixinMinecraftServer"
   ],
   "client": [
-    "client.MixinDebugOverlayGui",
-    "client.MixinMinecraft"
-
+    "client.MixinDebugOverlayGui"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This resolves an interaction issue with Quark where Big Dungeons can spawn inside BYG End Biomes.

I'm not sure what the fillBiomeDictionary method on line 302 does, but it doesn't seem to register them properly for other mods to use.