### PR TITLE
make byg villages separate structures so /locate works [fabric 1.16.5]

### DIFF
--- a/src/main/java/corgiaoc/byg/core/world/BYGConfiguredStructures.java
+++ b/src/main/java/corgiaoc/byg/core/world/BYGConfiguredStructures.java
@@ -9,19 +9,19 @@ import net.minecraft.world.level.levelgen.feature.configurations.JigsawConfigura
 
 public class BYGConfiguredStructures {
 
-    public static final ConfiguredStructureFeature<JigsawConfiguration, ? extends StructureFeature<JigsawConfiguration>> VILLAGE_SKYRIS = register("village_skyris", StructureFeature.VILLAGE.configured(new JigsawConfiguration(() -> {
+    public static final ConfiguredStructureFeature<JigsawConfiguration, ? extends StructureFeature<JigsawConfiguration>> VILLAGE_SKYRIS = register("village_skyris", BYGStructures.SKYRIS_VILLAGE.configured(new JigsawConfiguration(() -> {
         return SkyrisVillagePools.SkyrisVillageJigsaw;
     }, 6)));
 
-    public static final ConfiguredStructureFeature<JigsawConfiguration, ? extends StructureFeature<JigsawConfiguration>> VILLAGE_RUINS = register("village_ruins", StructureFeature.VILLAGE.configured(new JigsawConfiguration(() -> {
+    public static final ConfiguredStructureFeature<JigsawConfiguration, ? extends StructureFeature<JigsawConfiguration>> VILLAGE_RUINS = register("village_ruins", BYGStructures.RUINS_VILLAGE.configured(new JigsawConfiguration(() -> {
         return RuinsVillagePools.RuinsVillageJigsaw;
     }, 6)));
 
-    public static final ConfiguredStructureFeature<JigsawConfiguration, ? extends StructureFeature<JigsawConfiguration>> VILLAGE_ADOBE = register("village_adobe", StructureFeature.VILLAGE.configured(new JigsawConfiguration(() -> {
+    public static final ConfiguredStructureFeature<JigsawConfiguration, ? extends StructureFeature<JigsawConfiguration>> VILLAGE_ADOBE = register("village_adobe", BYGStructures.ADOBE_VILLAGE.configured(new JigsawConfiguration(() -> {
         return AdobeVillagePools.ADOBE_VILLAGE_JIGSAW;
     }, 6)));
 
-    public static final ConfiguredStructureFeature<JigsawConfiguration, ? extends StructureFeature<JigsawConfiguration>> VILLAGE_TROPICAL = register("village_tropical", StructureFeature.VILLAGE.configured(new JigsawConfiguration(() -> {
+    public static final ConfiguredStructureFeature<JigsawConfiguration, ? extends StructureFeature<JigsawConfiguration>> VILLAGE_TROPICAL = register("village_tropical", BYGStructures.TROPICAL_VILLAGE.configured(new JigsawConfiguration(() -> {
         return TropicalVillagePools.TropicalVillageJigsaw;
     }, 6)));
 

--- a/src/main/java/corgiaoc/byg/core/world/BYGStructures.java
+++ b/src/main/java/corgiaoc/byg/core/world/BYGStructures.java
@@ -2,8 +2,11 @@ package corgiaoc.byg.core.world;
 
 import corgiaoc.byg.common.world.structure.largefeature.VolcanoPiece;
 import corgiaoc.byg.core.world.util.WorldGenRegistrationHelper;
+import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.feature.StructureFeature;
 import net.minecraft.world.level.levelgen.feature.StructurePieceType;
+import net.minecraft.world.level.levelgen.feature.VillageFeature;
+import net.minecraft.world.level.levelgen.feature.configurations.JigsawConfiguration;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +21,10 @@ public class BYGStructures {
 
 //    public static final Structure<NoFeatureConfig> VOLCANO_STRUCTURE = WorldGenRegistrationHelper.createStructure("volcano", new VolcanoStructure(NoFeatureConfig.CODEC), 10, 0, 0,  GenerationStage.Decoration.RAW_GENERATION);
 //    public static final Structure<VillageConfig> BYG_VILLAGE = WorldGenRegistrationHelper.createStructure("byg_village", new VillageStructure(VillageConfig.CODEC), 3, 0, 0,  GenerationStage.Decoration.SURFACE_STRUCTURES);
-
+    public static StructureFeature<JigsawConfiguration> ADOBE_VILLAGE = WorldGenRegistrationHelper.createStructure("adobe_village", new VillageFeature(JigsawConfiguration.CODEC), 32, 8, 247532335, GenerationStep.Decoration.SURFACE_STRUCTURES, true);
+    public static StructureFeature<JigsawConfiguration> RUINS_VILLAGE = WorldGenRegistrationHelper.createStructure("ruins_village", new VillageFeature(JigsawConfiguration.CODEC), 32, 8, 98984785, GenerationStep.Decoration.SURFACE_STRUCTURES, true);
+    public static StructureFeature<JigsawConfiguration> TROPICAL_VILLAGE = WorldGenRegistrationHelper.createStructure("tropical_village", new VillageFeature(JigsawConfiguration.CODEC), 32, 8, 233315243, GenerationStep.Decoration.SURFACE_STRUCTURES, true);
+    public static StructureFeature<JigsawConfiguration> SKYRIS_VILLAGE = WorldGenRegistrationHelper.createStructure("skyris_village", new VillageFeature(JigsawConfiguration.CODEC), 32, 8, 889865932, GenerationStep.Decoration.SURFACE_STRUCTURES, true);
 
     public static void init() {
     }

--- a/src/main/java/corgiaoc/byg/entrypoint/FabricEntryPoint.java
+++ b/src/main/java/corgiaoc/byg/entrypoint/FabricEntryPoint.java
@@ -9,6 +9,7 @@ import corgiaoc.byg.util.MLBlockTags;
 import corgiaoc.byg.util.NetworkUtil;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.core.Registry;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
@@ -21,6 +22,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.feature.StructureFeature;
 import net.minecraft.world.level.levelgen.feature.blockplacers.BlockPlacerType;
 import net.minecraft.world.level.levelgen.placement.FeatureDecorator;
 import net.minecraft.world.level.levelgen.structure.templatesystem.TagMatchTest;
@@ -139,8 +141,7 @@ public class FabricEntryPoint implements EntryPoint, ModInitializer {
     public static void registerStructures() {
         BYG.LOGGER.debug("BYG: Registering structures...");
         BYGStructures.init();
-//            BYGStructures.structures.forEach(structure -> event.getRegistry().register(structure));
-//            Structure.STRUCTURE_DECORATION_STAGE_MAP.forEach(((structure, decoration) -> System.out.println(Registry.STRUCTURE_FEATURE.getKey(structure).toString())));
+        List<StructureFeature<?>> structureFeatures = BYGStructures.structures;
         BYG.LOGGER.info("BYG: Structures registered!");
     }
 

--- a/src/main/java/corgiaoc/byg/mixin/access/DimensionStructuresSettingsAccess.java
+++ b/src/main/java/corgiaoc/byg/mixin/access/DimensionStructuresSettingsAccess.java
@@ -5,7 +5,10 @@ import net.minecraft.world.level.levelgen.StructureSettings;
 import net.minecraft.world.level.levelgen.feature.StructureFeature;
 import net.minecraft.world.level.levelgen.feature.configurations.StructureFeatureConfiguration;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Map;
 
 @Mixin(StructureSettings.class)
 public interface DimensionStructuresSettingsAccess {
@@ -14,4 +17,8 @@ public interface DimensionStructuresSettingsAccess {
     static void setDefaults(ImmutableMap<StructureFeature<?>, StructureFeatureConfiguration> newMap) {
         throw new Error("Mixin did not apply!");
     }
+
+    @Mutable
+    @Accessor("structureConfig")
+    void setStructureConfig(Map<StructureFeature<?>, StructureFeatureConfiguration> structureConfig);
 }


### PR DESCRIPTION
/locate now can find all 4 byg villages directly so no more using /locate village and praying lol. This should make it easier to do separate base structures for other byg structures so they too can be found with /locate directly