### PR TITLE
Fix typo in french language

### DIFF
--- a/src/main/resources/assets/byg/lang/fr_fr.json
+++ b/src/main/resources/assets/byg/lang/fr_fr.json
@@ -378,7 +378,7 @@
   "block.byg.ebony_fence_gate": "Portillon en Ébène",
   "block.byg.ebony_leaves": "Feuilles d'Ébène",
   "block.byg.ebony_log": "Bûche d'Ébène",
-  "block.byg.ebony_planks": "Blanches d'Ébène",
+  "block.byg.ebony_planks": "Planches d'Ébène",
   "block.byg.ebony_pressure_plate": "Plaque de Pression en Ébène",
   "block.byg.ebony_sapling": "Pousse d'Ébène",
   "block.byg.ebony_slab": "Dalle d'Ébène",


### PR DESCRIPTION
"Blanches" is "Whites", but "Planches" is "planks"