### PR TITLE
Update pickaxe.json

### DIFF
--- a/Common/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/Common/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -64,6 +64,7 @@
     "byg:frost_magma",
     "byg:subzero_crystal_block",
     "byg:budding_subzero_crystal",
+    "byg:subzero_crystal_cluster",
     "byg:black_sandstone",
     "byg:black_chiseled_sandstone",
     "byg:black_cut_sandstone",


### PR DESCRIPTION
Fixes bug that was preventing Subzero Crystal Cluster item from dropping when mining them from the block.