### PR TITLE
[1.19] Add splitter to biome builder config

### DIFF
--- a/Common/src/main/java/potionstudios/byg/common/world/biome/overworld/BYGOverworldBiomeSelectors.java
+++ b/Common/src/main/java/potionstudios/byg/common/world/biome/overworld/BYGOverworldBiomeSelectors.java
@@ -61,6 +61,13 @@ public class BYGOverworldBiomeSelectors {
             """, fallback);
     }
 
+    private static String invalidKeysOkay2(String fallback) {
+        return String.format("""
+            All keys passed in must be valid in the biome registry!
+            In slots containing "minecraft:the_void", biomes at the equivalent temperature/humidity fall back to "%s" instead.
+            """, fallback);
+    }
+
     public static final String PEAK_BIOMES_LAYOUT = "Appearing on mountainous terrain & BELOW weirdness 0, here is the \"peak_biomes\" layout:\n" + BIOME_LAYOUT + REQUIRES_VALID_KEYS;
 
     public static final String SLOPE_BIOMES_LAYOUT = "Appearing on sloped terrain, near mountainous terrain, & BELOW weirdness 0, here is the \"slope_biomes\" layout:\n" + BIOME_LAYOUT + REQUIRES_VALID_KEYS;
@@ -79,6 +86,11 @@ public class BYGOverworldBiomeSelectors {
     public static final String MIDDLE_BIOMES_VARIANT_LAYOUT = "Appearing on terrain ABOVE weirdness 0, here is the \"middle_biomes_variant\" layout:\n" + BIOME_LAYOUT + invalidKeysOkay("middle_biomes");
 
     public static final String BEACH_BIOMES_LAYOUT = "Appearing on terrain bordering oceans, here is the \"beach_biomes\" layout:\n" + BIOME_LAYOUT + REQUIRES_VALID_KEYS;
+
+    public static String splitterLayout(String biome, String name) {
+        return String.format("Appearing instead of \"%s\", here is the \"%s\" layout: " + BIOME_LAYOUT + invalidKeysOkay2(biome),
+                biome, name);
+    }
 
     protected static final Wrapped<List<List<ResourceKey<Biome>>>> OCEANS_VANILLA = create("oceans/oceans_vanilla", OCEANS_BIOMES_LAYOUT_COMMENT, new ResourceKey[][]{
         {Biomes.DEEP_FROZEN_OCEAN, Biomes.DEEP_COLD_OCEAN, Biomes.DEEP_OCEAN, Biomes.DEEP_LUKEWARM_OCEAN, Biomes.WARM_OCEAN},
@@ -148,8 +160,8 @@ public class BYGOverworldBiomeSelectors {
     protected static final Wrapped<List<List<ResourceKey<Biome>>>> BEACH_BIOMES_1 = create("beach_biomes/beach_biomes_1", BEACH_BIOMES_LAYOUT, new ResourceKey[][]{
             {Biomes.SNOWY_BEACH, Biomes.SNOWY_BEACH, Biomes.SNOWY_BEACH, Biomes.SNOWY_BEACH, Biomes.SNOWY_BEACH},
             {Biomes.BEACH, Biomes.BEACH, Biomes.BEACH, Biomes.BEACH, Biomes.BEACH},
-            {BYGBiomes.BASALT_BARRERA, BYGBiomes.BASALT_BARRERA, BYGBiomes.BASALT_BARRERA, BYGBiomes.BASALT_BARRERA, BYGBiomes.BASALT_BARRERA},
-            {BYGBiomes.RAINBOW_BEACH, BYGBiomes.RAINBOW_BEACH, BYGBiomes.RAINBOW_BEACH, BYGBiomes.RAINBOW_BEACH, BYGBiomes.RAINBOW_BEACH},
+            {Biomes.BEACH, Biomes.BEACH, Biomes.BEACH, Biomes.BEACH, Biomes.BEACH},
+            {Biomes.BEACH, Biomes.BEACH, Biomes.BEACH, BYGBiomes.RAINBOW_BEACH, BYGBiomes.RAINBOW_BEACH},
             {BYGBiomes.WINDSWEPT_DESERT, BYGBiomes.WINDSWEPT_DESERT, BYGBiomes.WINDSWEPT_DESERT, BYGBiomes.WINDSWEPT_DESERT, BYGBiomes.WINDSWEPT_DESERT}
     });
 
@@ -235,6 +247,14 @@ public class BYGOverworldBiomeSelectors {
             {BYGBiomes.GROVE, BYGBiomes.ORCHARD, BYGBiomes.ASPEN_FOREST, BYGBiomes.ALLIUM_FIELDS, BYGBiomes.DACITE_RIDGES},
             {BYGBiomes.BAOBAB_SAVANNA, BYGBiomes.ARAUCARIA_SAVANNA, BYGBiomes.EBONY_WOODS, BYGBiomes.AMARANTH_FIELDS, BYGBiomes.GUIANA_SHIELD},
             {BYGBiomes.FIRECRACKER_SHRUBLAND, BYGBiomes.SIERRA_BADLANDS, BYGBiomes.SIERRA_BADLANDS, BYGBiomes.RED_ROCK_VALLEY, BYGBiomes.RED_ROCK_VALLEY}
+    });
+
+    protected static final Wrapped<List<List<ResourceKey<Biome>>>> STONY_SHORES_1 = create("splitters/stony_shores_1", splitterLayout("minecraft:stony_shore", "stony_shores"), new ResourceKey[][]{
+            {BYGBiomes.BASALT_BARRERA, BYGBiomes.BASALT_BARRERA, BYGBiomes.DACITE_SHORE, BYGBiomes.DACITE_SHORE, BYGBiomes.DACITE_SHORE},
+            {BYGBiomes.BASALT_BARRERA, BYGBiomes.BASALT_BARRERA, BYGBiomes.DACITE_SHORE, BYGBiomes.DACITE_SHORE, BYGBiomes.DACITE_SHORE},
+            {BYGBiomes.BASALT_BARRERA, BYGBiomes.BASALT_BARRERA, BYGBiomes.DACITE_SHORE, BYGBiomes.DACITE_SHORE, BYGBiomes.DACITE_SHORE},
+            {BYGBiomes.BASALT_BARRERA, BYGBiomes.BASALT_BARRERA, BYGBiomes.BASALT_BARRERA, BYGBiomes.BASALT_BARRERA, BYGBiomes.BASALT_BARRERA},
+            {Biomes.THE_VOID, Biomes.THE_VOID, Biomes.THE_VOID, Biomes.THE_VOID, Biomes.THE_VOID}
     });
 
     protected static Wrapped<List<List<ResourceKey<Biome>>>> create(String id, String header, ResourceKey<Biome>[][] biomeKeys) {

--- a/Common/src/main/java/potionstudios/byg/mixin/access/OverworldBiomeBuilderAccess.java
+++ b/Common/src/main/java/potionstudios/byg/mixin/access/OverworldBiomeBuilderAccess.java
@@ -35,4 +35,13 @@ public interface OverworldBiomeBuilderAccess {
 
     @Invoker("addBiomes")
     void byg_invokeAddBiomes(Consumer<Pair<Climate.ParameterPoint, ResourceKey<Biome>>> mapper);
+
+    @Accessor
+    Climate.Parameter[] getTemperatures();
+
+    @Accessor
+    Climate.Parameter[] getHumidities();
+
+    @Accessor("FULL_RANGE")
+    Climate.Parameter getFullRange();
 }

--- a/Common/src/main/java/potionstudios/byg/util/BYGUtil.java
+++ b/Common/src/main/java/potionstudios/byg/util/BYGUtil.java
@@ -16,6 +16,7 @@ import potionstudios.byg.BYG;
 import potionstudios.byg.common.world.biome.LayersBiomeData;
 import potionstudios.byg.mixin.access.WeightedEntryWrapperAccess;
 import potionstudios.byg.mixin.access.WeightedListAccess;
+import potionstudios.byg.util.codec.Wrapped;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -56,6 +57,15 @@ public class BYGUtil {
         }
 
         return resultList.toArray(ResourceKey[][]::new);
+    }
+
+    public static <T> Map<ResourceKey<T>, ResourceKey<T>[][]> mapOfWrappedListToMapOf2DArray(
+            Map<ResourceKey<T>, Wrapped<List<List<ResourceKey<T>>>>> mapToConvert) {
+        Map<ResourceKey<T>, ResourceKey<T>[][]> resultMap = new IdentityHashMap<>();
+        for(Map.Entry<ResourceKey<T>, Wrapped<List<List<ResourceKey<T>>>>> entry : mapToConvert.entrySet()) {
+            resultMap.put(entry.getKey(), _2DResourceKeyArrayTo2DList(entry.getValue().value()));
+        }
+        return resultMap;
     }
 
     public static <T> String print2DResourceKeyArray(ResourceKey<T>[][] valueToPrint) {

--- a/Fabric/src/main/java/potionstudios/byg/world/biome/BYGTerraBlenderRegion.java
+++ b/Fabric/src/main/java/potionstudios/byg/world/biome/BYGTerraBlenderRegion.java
@@ -23,12 +23,14 @@ import java.util.function.Predicate;
 import static potionstudios.byg.util.BYGRegionUtils.dumpArrays;
 import static potionstudios.byg.util.BYGRegionUtils.filter;
 import static potionstudios.byg.util.BYGUtil._2DResourceKeyArrayTo2DList;
+import static potionstudios.byg.util.BYGUtil.mapOfWrappedListToMapOf2DArray;
 
 public class BYGTerraBlenderRegion extends Region {
     private static int count = 0;
 
     private final Set<ResourceKey<Biome>> bygKeys = new ObjectOpenHashSet<>();
     private final Map<ResourceKey<Biome>, ResourceKey<Biome>> swapper;
+    private final Map<ResourceKey<Biome>, ResourceKey<Biome>[][]> splitter;
 
     private final BYGOverworldBiomeBuilder bygOverworldBiomeBuilder;
 
@@ -45,7 +47,8 @@ public class BYGTerraBlenderRegion extends Region {
                 _2DResourceKeyArrayTo2DList(overworldRegion.peakBiomesVariant().value()),
                 _2DResourceKeyArrayTo2DList(overworldRegion.slopeBiomes().value()),
                 _2DResourceKeyArrayTo2DList(overworldRegion.slopeBiomesVariant().value()),
-                overworldRegion.swapper());
+                overworldRegion.swapper(),
+                mapOfWrappedListToMapOf2DArray(overworldRegion.splitter()));
     }
 
     public BYGTerraBlenderRegion(int overworldWeight,
@@ -54,9 +57,11 @@ public class BYGTerraBlenderRegion extends Region {
                                  ResourceKey<Biome>[][] plateauBiomesVariant, ResourceKey<Biome>[][] shatteredBiomes,
                                  ResourceKey<Biome>[][] beachBiomes, ResourceKey<Biome>[][] peakBiomes,
                                  ResourceKey<Biome>[][] peakBiomesVariant, ResourceKey<Biome>[][] slopeBiomes, ResourceKey<Biome>[][] slopeBiomesVariant,
-                                 Map<ResourceKey<Biome>, ResourceKey<Biome>> swapper) {
+                                 Map<ResourceKey<Biome>, ResourceKey<Biome>> swapper,
+                                 Map<ResourceKey<Biome>, ResourceKey<Biome>[][]> splitter) {
         super(BYG.createLocation("region_" + count++), RegionType.OVERWORLD, overworldWeight);
         this.swapper = swapper;
+        this.splitter = splitter;
         Predicate<ResourceKey<Biome>> noVoidBiomes = biomeResourceKey -> biomeResourceKey != Biomes.THE_VOID;
         oceans = filter("oceans", this.getName(), count, oceans, noVoidBiomes, true);
         middleBiomes = filter("middle_biomes", this.getName(), count, middleBiomes, noVoidBiomes, true);
@@ -79,17 +84,34 @@ public class BYGTerraBlenderRegion extends Region {
         dumpArrays((biomeResourceKey -> {
             if (biomeResourceKey != null) {
                 bygKeys.add(biomeResourceKey);
-                if (swapper.containsValue(biomeResourceKey)) {
-                    throw new IllegalArgumentException("Swapper cannot contain elements found in the temperature arrays.");
+                if (swapper.containsKey(biomeResourceKey)) {
+                    throw new IllegalArgumentException("Swapper cannot swap elements found in the temperature arrays.");
+                }
+                if (splitter.containsKey(biomeResourceKey)) {
+                    throw new IllegalArgumentException("Splitter cannot split elements found in the temperature arrays.");
                 }
             }
-        }), oceans, middleBiomes, middleBiomesVariant, plateauBiomes, plateauBiomesVariant, shatteredBiomes, beachBiomes, peakBiomes);
+        }), oceans, middleBiomes, middleBiomesVariant, plateauBiomes, plateauBiomesVariant, shatteredBiomes, beachBiomes, 
+                peakBiomes, peakBiomesVariant, slopeBiomes, slopeBiomesVariant);
+        for(ResourceKey<Biome>[][] array : splitter.values())
+        {
+            dumpArrays(biomeResourceKey -> {
+                bygKeys.add(biomeResourceKey);
+                if(swapper.containsKey(biomeResourceKey)) {
+                    throw new IllegalArgumentException("Swapper cannot swap elements found in splitters.");
+                }
+                if(splitter.containsKey(biomeResourceKey)) {
+                    throw new IllegalArgumentException("Splitter cannot split biomes from its own temperature arrays.");
+                }
+            });
+        }
     }
 
     @Override
     public void addBiomes(Registry<Biome> registry, Consumer<Pair<Climate.ParameterPoint, ResourceKey<Biome>>> mapper) {
         MutableInt totalPairs = new MutableInt();
         MutableInt bygMapperAccepted = new MutableInt(0);
+        OverworldBiomeBuilderAccess access = (OverworldBiomeBuilderAccess) this.bygOverworldBiomeBuilder;
         ((OverworldBiomeBuilderAccess) this.bygOverworldBiomeBuilder).byg_invokeAddBiomes((parameterPointResourceKeyPair -> {
             ResourceKey<Biome> biomeKey = parameterPointResourceKeyPair.getSecond();
             if (!registry.containsKey(biomeKey)) {
@@ -98,16 +120,51 @@ public class BYGTerraBlenderRegion extends Region {
             totalPairs.increment();
             boolean mapped = false;
             boolean alreadyMappedOutsideSwapper = false;
+            boolean alreadyMappedInSplitter = false;
             if (this.bygKeys.contains(biomeKey)) {
                 mapper.accept(new Pair<>(parameterPointResourceKeyPair.getFirst(), biomeKey));
                 bygMapperAccepted.increment();
                 alreadyMappedOutsideSwapper = true;
                 mapped = true;
             }
-
+            if (this.splitter.containsKey(biomeKey)) {
+                if (alreadyMappedOutsideSwapper) {
+                    throw new UnsupportedOperationException(String.format("Attempting to assign a biome resource key in both the splitter and biome selectors. We're crashing your game to let you know that \"%s\" was put in the biome selectors but will always be swapped by \"%s\" due to the swapper. In region \"%s\".", biomeKey.location().toString(), this.swapper.get(biomeKey).location().toString(), this.getName().toString()));
+                }
+                ResourceKey<Biome>[][] array = splitter.get(biomeKey);
+                Climate.ParameterPoint sourceParam = parameterPointResourceKeyPair.getFirst();
+                if(!sourceParam.temperature().equals(access.getFullRange()) &&
+                !sourceParam.humidity().equals(access.getFullRange())) {
+                    throw new IllegalArgumentException(String.format("Biome \"%s\" doesn't cover the full temperature/humidity range and therefore cannot be put in the splitter.\n" +
+                            "Temperature range: %s, Humidity range: %s", biomeKey.location().toString(), sourceParam.temperature().toString(), sourceParam.humidity().toString()));
+                }
+                for(int i = 0; i < array.length; i++) {
+                    for (int j = 0; j < array[i].length; j++)
+                    {
+                        ResourceKey<Biome> resultKey = array[i][j];
+                        if(resultKey.equals(Biomes.THE_VOID))
+                            resultKey = biomeKey;
+                        mapper.accept(new Pair<>(new Climate.ParameterPoint(
+                                access.getTemperatures()[i],
+                                access.getHumidities()[j],
+                                sourceParam.continentalness(),
+                                sourceParam.erosion(),
+                                sourceParam.depth(),
+                                sourceParam.weirdness(),
+                                sourceParam.offset()
+                        ), resultKey));
+                    }
+                }
+                bygMapperAccepted.increment();
+                alreadyMappedInSplitter = true;
+                mapped = true;
+            }
             if (this.swapper.containsKey(biomeKey)) {
                 if (alreadyMappedOutsideSwapper) {
                     throw new UnsupportedOperationException(String.format("Attempting to assign a biome resource key in both the swapper and biome selectors. We're crashing your game to let you know that \"%s\" was put in the biome selectors but will always be swapped by \"%s\" due to the swapper. In region \"%s\".", biomeKey.location().toString(), this.swapper.get(biomeKey).location().toString(), this.getName().toString()));
+                }
+                if (alreadyMappedInSplitter) {
+                    throw new UnsupportedOperationException(String.format("Attempting to assign a biome resource key in both the swapper and the splitter. We're crashing your game to let you know that \"%s\" was put in the splitter. In region \"%s\".", biomeKey.location().toString(), this.getName().toString()));
                 }
                 mapper.accept(new Pair<>(parameterPointResourceKeyPair.getFirst(), this.swapper.get(biomeKey)));
                 bygMapperAccepted.increment();


### PR DESCRIPTION
Adds a `splitter` to region config files, which is similar to the `swapper`, but replaces the vanilla biome with a temperature/humidity array like in `middle_biomes`. It's useful for biomes like `stony_shore` and `mushroom_fields`.
Right now it supports only vanilla biomes that span the full range of temperature and humidity as keys.

Beach biome arrays were also adjusted, `byg:basalt_barrera` now replaces stony shores, and `byg:dacite_shore` does not generate in warm climate regions.

Additionally, an error where you cannot put a biome from temperature arrays in the `swapper`'s *value* is now fixed, the issue is where the `swapper` tries to swap using the *key* that's already found in the biome selectors. Errors for `splitter` keys are handled accordingly.

It should be backwards compatible with current and old config files, just adding an empty map for `splitter`.