### PR TITLE
Provide Ametrine Knockback Resistance greater than Netherite

### DIFF
--- a/Common/src/main/java/potionstudios/byg/common/item/BYGArmorMaterial.java
+++ b/Common/src/main/java/potionstudios/byg/common/item/BYGArmorMaterial.java
@@ -67,6 +67,6 @@ public class BYGArmorMaterial implements ArmorMaterial {
 
     @Override
     public float getKnockbackResistance() {
-        return 0;
+        return 1.2F;
     }
 }


### PR DESCRIPTION
An extremely small pull request; simply modifies Ametrine Armor to have a greater Knockback resistance than Netherite. 

I won't be particularly hurt if this gets rejected; I tried to ask about this on the Discord server. 😅

