### PR TITLE
Sandstone Tweaks

### DIFF
--- a/Common/src/main/resources/data/byg/recipes/black_smooth_sandstone.json
+++ b/Common/src/main/resources/data/byg/recipes/black_smooth_sandstone.json
@@ -1,8 +1,9 @@
 {
-  "type": "minecraft:stonecutting",
+  "type": "minecraft:smelting",
+  "cookingtime": 200,
+  "experience": 0.1,
   "ingredient": {
     "item": "byg:black_sandstone"
   },
-  "result": "byg:black_smooth_sandstone",
-  "count": 1
+  "result": "byg:black_smooth_sandstone"
 }

--- a/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_from_windswept_sandstone_stonecutting.json
+++ b/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_from_windswept_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:windswept_sandstone"
+  },
+  "result": "byg:chiseled_windswept_sandstone"
+}

--- a/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_slab.json
+++ b/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_slab.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "key": {
+    "#": {
+      "item": "byg:chiseled_windswept_sandstone"
+    }
+  },
+  "pattern": [
+    "###"
+  ],
+  "result": {
+    "count": 6,
+    "item": "byg:chiseled_windswept_sandstone_slab"
+  }
+}

--- a/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_slab_from_chiseled_windswept_sandstone_stonecutting.json
+++ b/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_slab_from_chiseled_windswept_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "byg:chiseled_windswept_sandstone"
+  },
+  "result": "byg:chiseled_windswept_sandstone_slab"
+}

--- a/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_slab_from_windswept_sandstone_stonecutting.json
+++ b/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_slab_from_windswept_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "byg:windswept_sandstone"
+  },
+  "result": "byg:chiseled_windswept_sandstone_slab"
+}

--- a/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_stairs_from_chiseled_windswept_sandstone_stonecutter.json
+++ b/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_stairs_from_chiseled_windswept_sandstone_stonecutter.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:chiseled_windswept_sandstone"
+  },
+  "result": "byg:chiseled_windswept_sandstone_stairs"
+}

--- a/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_stairs_from_windswept_sandstone_stonecutter.json
+++ b/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_stairs_from_windswept_sandstone_stonecutter.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:windswept_sandstone"
+  },
+  "result": "byg:chiseled_windswept_sandstone_stairs"
+}

--- a/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_wall.json
+++ b/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_wall.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "key": {
+    "#": {
+      "item": "byg:chiseled_windswept_sandstone"
+    }
+  },
+  "pattern": [
+    "###",
+    "###"
+  ],
+  "result": {
+    "count": 6,
+    "item": "byg:chiseled_windswept_sandstone_wall"
+  }
+}

--- a/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_wall_from_chiseled_windswept_sandstone_stonecutter.json
+++ b/Common/src/main/resources/data/byg/recipes/chiseled_windswept_sandstone_wall_from_chiseled_windswept_sandstone_stonecutter.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:chiseled_windswept_sandstone"
+  },
+  "result": "byg:chiseled_windswept_sandstone_wall"
+}

--- a/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone.json
+++ b/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "key": {
+    "#": {
+      "item": "byg:windswept_sandstone"
+    }
+  },
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "result": {
+    "count": 4,
+    "item": "byg:cut_windswept_sandstone"
+  }
+}

--- a/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_from_windswept_sandstone_stonecutting.json
+++ b/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_from_windswept_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:windswept_sandstone"
+  },
+  "result": "byg:cut_windswept_sandstone"
+}

--- a/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_slab.json
+++ b/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_slab.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "key": {
+    "#": {
+      "item": "byg:cut_windswept_sandstone"
+    }
+  },
+  "pattern": [
+    "###"
+  ],
+  "result": {
+    "count": 6,
+    "item": "byg:cut_windswept_sandstone_slab"
+  }
+}

--- a/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_slab_from_cut_windswept_sandstone_stonecutting.json
+++ b/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_slab_from_cut_windswept_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "byg:cut_windswept_sandstone"
+  },
+  "result": "byg:cut_windswept_sandstone_slab"
+}

--- a/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_slab_from_windswept_sandstone_stonecutting.json
+++ b/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_slab_from_windswept_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "byg:windswept_sandstone"
+  },
+  "result": "byg:cut_windswept_sandstone_slab"
+}

--- a/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_stairs_from_cut_windswept_sandstone_stonecutter.json
+++ b/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_stairs_from_cut_windswept_sandstone_stonecutter.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:cut_windswept_sandstone"
+  },
+  "result": "byg:cut_windswept_sandstone_stairs"
+}

--- a/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_stairs_from_windswept_sandstone_stonecutter.json
+++ b/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_stairs_from_windswept_sandstone_stonecutter.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:windswept_sandstone"
+  },
+  "result": "byg:cut_windswept_sandstone_stairs"
+}

--- a/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_wall.json
+++ b/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_wall.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "key": {
+    "#": {
+      "item": "byg:cut_windswept_sandstone"
+    }
+  },
+  "pattern": [
+    "###",
+    "###"
+  ],
+  "result": {
+    "count": 6,
+    "item": "byg:cut_windswept_sandstone_wall"
+  }
+}

--- a/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_wall_from_cut_windswept_sandstone_stonecutter.json
+++ b/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_wall_from_cut_windswept_sandstone_stonecutter.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:cut_windswept_sandstone"
+  },
+  "result": "byg:cut_windswept_sandstone_wall"
+}

--- a/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_wall_from_windswept_sandstone_stonecutter.json
+++ b/Common/src/main/resources/data/byg/recipes/cut_windswept_sandstone_wall_from_windswept_sandstone_stonecutter.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:windswept_sandstone"
+  },
+  "result": "byg:chiseled_windswept_sandstone_wall"
+}

--- a/Common/src/main/resources/data/byg/recipes/pink_smooth_sandstone.json
+++ b/Common/src/main/resources/data/byg/recipes/pink_smooth_sandstone.json
@@ -1,5 +1,7 @@
 {
-  "type": "minecraft:stonecutting",
+  "type": "minecraft:smelting",
+  "cookingtime": 200,
+  "experience": 0.1,
   "ingredient": {
     "item": "byg:pink_sandstone"
   },

--- a/Common/src/main/resources/data/byg/recipes/purple_smooth_sandstone.json
+++ b/Common/src/main/resources/data/byg/recipes/purple_smooth_sandstone.json
@@ -1,5 +1,7 @@
 {
-  "type": "minecraft:stonecutting",
+  "type": "minecraft:smelting",
+  "cookingtime": 200,
+  "experience": 0.1,
   "ingredient": {
     "item": "byg:purple_sandstone"
   },

--- a/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone.json
+++ b/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone.json
@@ -3,8 +3,7 @@
   "cookingtime": 200,
   "experience": 0.1,
   "ingredient": {
-    "item": "byg:blue_sandstone"
+    "item": "byg:windswept_sandstone"
   },
-  "result": "byg:blue_smooth_sandstone",
-  "count": 1
+  "result": "byg:smooth_windswept_sandstone"
 }

--- a/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone_from_windswept_sandstone_stonecutting.json
+++ b/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone_from_windswept_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:windswept_sandstone"
+  },
+  "result": "byg:smooth_windswept_sandstone"
+}

--- a/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone_slab.json
+++ b/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone_slab.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "key": {
+    "#": {
+      "item": "byg:smooth_windswept_sandstone"
+    }
+  },
+  "pattern": [
+    "###"
+  ],
+  "result": {
+    "count": 6,
+    "item": "byg:smooth_windswept_sandstone_slab"
+  }
+}

--- a/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone_slab_from_smooth_windswept_sandstone_stonecutting.json
+++ b/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone_slab_from_smooth_windswept_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "byg:smooth_windswept_sandstone"
+  },
+  "result": "byg:smooth_windswept_sandstone_slab"
+}

--- a/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone_stairs.json
+++ b/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone_stairs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "key": {
+    "#": {
+      "item": "byg:smooth_windswept_sandstone"
+    }
+  },
+  "pattern": [
+    "#",
+    "##",
+    "###"
+  ],
+  "result": {
+    "count": 4,
+    "item": "byg:smooth_windswept_sandstone_stairs"
+  }
+}

--- a/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone_stairs_from_smooth_windswept_sandstone_stonecutter.json
+++ b/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone_stairs_from_smooth_windswept_sandstone_stonecutter.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:smooth_windswept_sandstone"
+  },
+  "result": "byg:smooth_windswept_sandstone_stairs"
+}

--- a/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone_wall.json
+++ b/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone_wall.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "key": {
+    "#": {
+      "item": "byg:smooth_windswept_sandstone"
+    }
+  },
+  "pattern": [
+    "###",
+    "###"
+  ],
+  "result": {
+    "count": 6,
+    "item": "byg:smooth_windswept_sandstone_wall"
+  }
+}

--- a/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone_wall_from_smooth_windswept_sandstone_stonecutter.json
+++ b/Common/src/main/resources/data/byg/recipes/smooth_windswept_sandstone_wall_from_smooth_windswept_sandstone_stonecutter.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:smooth_windswept_sandstone"
+  },
+  "result": "byg:smooth_windswept_sandstone_wall"
+}

--- a/Common/src/main/resources/data/byg/recipes/white_smooth_sandstone.json
+++ b/Common/src/main/resources/data/byg/recipes/white_smooth_sandstone.json
@@ -1,5 +1,7 @@
 {
-  "type": "minecraft:stonecutting",
+  "type": "minecraft:smelting",
+  "cookingtime": 200,
+  "experience": 0.1,
   "ingredient": {
     "item": "byg:white_sandstone"
   },

--- a/Common/src/main/resources/data/byg/recipes/windswept_sandstone_pillar.json
+++ b/Common/src/main/resources/data/byg/recipes/windswept_sandstone_pillar.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "#": {
-      "item": "byg:windswept_sandstone_slab"
+      "item": "byg:windswept_sandstone"
     }
   },
   "pattern": [
@@ -10,6 +10,6 @@
     "#"
   ],
   "result": {
-    "item": "byg:chiseled_windswept_chiseled_sandstone"
+    "item": "byg:windswept_sandstone_pillar"
   }
 }

--- a/Common/src/main/resources/data/byg/recipes/windswept_sandstone_pillar_from_windswept_sandstone.json
+++ b/Common/src/main/resources/data/byg/recipes/windswept_sandstone_pillar_from_windswept_sandstone.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:windswept_sandstone"
+  },
+  "result": "byg:windswept_sandstone_pillar"
+}

--- a/Common/src/main/resources/data/byg/recipes/windswept_sandstone_slab_from_windswept_sandstone_stonecutting.json
+++ b/Common/src/main/resources/data/byg/recipes/windswept_sandstone_slab_from_windswept_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 2,
+  "ingredient": {
+    "item": "byg:windswept_sandstone"
+  },
+  "result": "byg:windswept_sandstone_slab"
+}

--- a/Common/src/main/resources/data/byg/recipes/windswept_sandstone_stairs_from_windswept_sandstone_stonecutter.json
+++ b/Common/src/main/resources/data/byg/recipes/windswept_sandstone_stairs_from_windswept_sandstone_stonecutter.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:windswept_sandstone"
+  },
+  "result": "byg:windswept_sandstone_stairs"
+}

--- a/Common/src/main/resources/data/byg/recipes/windswept_sandstone_wall_from_windswept_sandstone_stonecutter.json
+++ b/Common/src/main/resources/data/byg/recipes/windswept_sandstone_wall_from_windswept_sandstone_stonecutter.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "byg:windswept_sandstone"
+  },
+  "result": "byg:windswept_sandstone_wall"
+}


### PR DESCRIPTION
Make Cut, Smooth, and Chiseled Windswept Sandstone Blocks, Slabs, and Walls craftable.
Make Windswept Sandstone Pillars Craftable.
Make smooth sandstone variants smelting recipes like vanilla smooth sandstone.