### PR TITLE
Fix crash with BYG saplings

### DIFF
--- a/Common/src/main/java/potionstudios/byg/common/block/sapling/BYGSaplingBlock.java
+++ b/Common/src/main/java/potionstudios/byg/common/block/sapling/BYGSaplingBlock.java
@@ -24,7 +24,7 @@ public class BYGSaplingBlock extends SaplingBlock implements FeatureGrowerFromBl
     private final TagKey<Block> groundTag;
 
     public BYGSaplingBlock(Properties properties, TagKey<Block> groundTag) {
-        super(null, properties);
+        super(new BYGTreeGrower(), properties);
         this.groundTag = groundTag;
         ENTRIES.add(() -> this);
     }

--- a/Common/src/main/java/potionstudios/byg/common/block/sapling/BYGTreeGrower.java
+++ b/Common/src/main/java/potionstudios/byg/common/block/sapling/BYGTreeGrower.java
@@ -1,0 +1,24 @@
+package potionstudios.byg.common.block.sapling;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.block.grower.AbstractTreeGrower;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkGenerator;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import org.jetbrains.annotations.Nullable;
+
+public class BYGTreeGrower extends AbstractTreeGrower {
+    @Nullable
+    @Override
+    protected Holder<? extends ConfiguredFeature<?, ?>> getConfiguredFeature(RandomSource randomSource, boolean b) {
+        return null;
+    }
+
+    @Override
+    public boolean growTree(ServerLevel $$0, ChunkGenerator $$1, BlockPos $$2, BlockState $$3, RandomSource $$4) {
+        return false;
+    }
+}


### PR DESCRIPTION
Caused by trying to invoke vanilla tree growth method on BYG saplings, patched with a blank tree grower