### PR TITLE
Add optional Soul Fire'd soft dependency.

### DIFF
--- a/Common/src/main/resources/data/soulfired/fires/byg.json
+++ b/Common/src/main/resources/data/soulfired/fires/byg.json
@@ -1,0 +1,13 @@
+{
+  "mod": "byg",
+  "fires": [
+    {
+      "fire": "boric",
+      "damage": 3.5
+    },
+    {
+      "fire": "cryptic",
+      "damage": 3.5
+    }
+  ]
+}

--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -52,5 +52,8 @@
     "corgilib": ">=3.0.0.0",
     "geckolib": ">=4.2.0"
   },
+  "suggests": {
+    "soulfired": ">=3.2.0.0"
+  },
   "accessWidener": "byg.aw"
 }

--- a/Forge/src/main/resources/META-INF/mods.toml
+++ b/Forge/src/main/resources/META-INF/mods.toml
@@ -49,3 +49,10 @@ mandatory = true
 versionRange = "[4.2,)"
 ordering = "BEFORE"
 side = "BOTH"
+
+[[dependencies.byg]]
+modId = "soulfired"
+mandatory = false
+versionRange = "[3.2,)"
+ordering = "NONE"
+side = "BOTH"


### PR DESCRIPTION
[Soul Fire'd](https://www.curseforge.com/minecraft/mc-mods/soul-fired) is a mod of mine with a dual aim:  

1. Add actually unique properties to Soul Fire.
2. Provide an easy-to-use API for other mods to register their own, or even of other mods, custom fires and having everything automatically handled.

I saw that BYG can benefit in both cases as it currently has 2 different fires that do not have unique properties.  
The way I integrated the API was via a soft dependency with a datapack.  
It's possible to integrate the API via code, but a soft dependency for an optional mod might be best to not slow down roll-outs of future versions and to avoid hard-coding.  
However, if by any chance you'd like to add fire enchantments for Boric and Cryptic fires, I can change the PR to instead integrate the API via code. In such case, Soul Fire'd could still be an optional dependency, but it couldn't be a soft dependency anymore.

By integrating the Soul Fire'd API, BYG gets unique properties and behavior for its fire types, along with consistent Soul Fire behavior.  
I also plan to expand the ecosystem with further PRs to other mods, such that they are all compatible with each other and there's no need for other mods to register fires of other mods.  
For example, Infernal Expansion is another mod I opened a PR to integrate Soul Fire'd API. If this PR is accepted, I could also change IE PR to not include handling of BYG fires.

If this PR is accepted, I can also start working on other Minecraft versions PRs (or actually it might be much easier and faster to cherry pick the changes in this PR).

Let me know if I did anything wrong when contributing or if something is not clear, or really anything in general.

Changes summary:
- **dependency list**
Added Soul Fire'd as an optional dependency for both Fabric and Forge.

- **Datapack**
Added a small datapack to integrate Soul Fire'd API when Soul Fire'd is present.